### PR TITLE
gunicorn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ packaging==20.4
 psycopg2-binary==2.8.6
 pynetbox==5.1.0
 requests==2.25.0
+gunicorn==20.0.4


### PR DESCRIPTION
the upgrade script deletes the virtualenv that also contains gunicorn. That means that on every upgrade, we have to re install it manually while it's still recommanded in the documentation to be installed.

### Fixes:

I added gunicorn to requirements.txt
