### PR TITLE
Default IRR Host Update

### DIFF
--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -144,7 +144,7 @@ to change this setting.
 
 ## BGPQ3_HOST
 
-Default: `rr.ntt.net`
+Default: `whois.radb.net`
 
 The host that will be used by BGPQ3 to look for IRR objects.
 

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -146,7 +146,7 @@ except (IOError, Exception):
 TIME_ZONE = getattr(configuration, "TIME_ZONE", BASE_TZ).rstrip()
 EMAIL = getattr(configuration, "EMAIL", {})
 BGPQ3_PATH = getattr(configuration, "BGPQ3_PATH", "bgpq3")
-BGPQ3_HOST = getattr(configuration, "BGPQ3_HOST", "rr.ntt.net")
+BGPQ3_HOST = getattr(configuration, "BGPQ3_HOST", "whois.radb.net")
 BGPQ3_SOURCES = getattr(
     configuration,
     "BGPQ3_SOURCES",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Updates:
- Changed default host from rr.ntt.net to whois.radb.net. RADB is a more
authoritative IRR source. #281 
<!--
    Please include a summary of the proposed changes below.
-->
