### PR TITLE
Modify IX & BGP Slug Warnings

### DIFF
--- a/peering/forms.py
+++ b/peering/forms.py
@@ -125,7 +125,7 @@ class AutonomousSystemEmailForm(BootstrapMixin, forms.Form):
 class BGPGroupForm(BootstrapMixin, forms.ModelForm):
     slug = SlugField(
         max_length=255,
-        help_text="Friendly unique shorthand used for URL and config. Change Warning: May result in change of Operational State on a Router if being used in config generation"
+        help_text="Friendly unique shorthand used for URL and config. Change Warning: May result in change of Operational State on a Router if being used in config generation",
     )
     comments = CommentField()
     import_routing_policies = DynamicModelMultipleChoiceField(
@@ -414,7 +414,7 @@ class EmailFilterForm(BootstrapMixin, forms.Form):
 class InternetExchangeForm(BootstrapMixin, forms.ModelForm):
     slug = SlugField(
         max_length=255,
-        help_text="Friendly unique shorthand used for URL and config. Change Warning: May result in change of Operational State on a Router if being used in config generation"
+        help_text="Friendly unique shorthand used for URL and config. Change Warning: May result in change of Operational State on a Router if being used in config generation",
     )
     local_autonomous_system = DynamicModelChoiceField(
         queryset=AutonomousSystem.objects.all(),

--- a/peering/forms.py
+++ b/peering/forms.py
@@ -123,7 +123,10 @@ class AutonomousSystemEmailForm(BootstrapMixin, forms.Form):
 
 
 class BGPGroupForm(BootstrapMixin, forms.ModelForm):
-    slug = SlugField(max_length=255)
+    slug = SlugField(
+        max_length=255,
+        help_text="Friendly unique shorthand used for URL and config. Change Warning: May result in change of Operational State on a Router if being used in config generation"
+    )
     comments = CommentField()
     import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
@@ -409,7 +412,10 @@ class EmailFilterForm(BootstrapMixin, forms.Form):
 
 
 class InternetExchangeForm(BootstrapMixin, forms.ModelForm):
-    slug = SlugField(max_length=255)
+    slug = SlugField(
+        max_length=255,
+        help_text="Friendly unique shorthand used for URL and config. Change Warning: May result in change of Operational State on a Router if being used in config generation"
+    )
     local_autonomous_system = DynamicModelChoiceField(
         queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
Closes #233 
- Modified Slug help text to display a warning that the operational state of a device may change if the slug is being used in config generation.
<!--
    Please include a summary of the proposed changes below.
-->
