### PR TITLE
Grab prefixes fix

### DIFF
--- a/peering/management/commands/grab_prefixes.py
+++ b/peering/management/commands/grab_prefixes.py
@@ -20,9 +20,8 @@ class Command(BaseCommand):
         self.logger.info("Getting prefixes for AS with IRR AS-SETs")
 
         for autonomous_system in AutonomousSystem.objects.all():
-            prefixes = autonomous_system.retrieve_irr_as_set_prefixes()
-
             try:
+                prefixes = autonomous_system.retrieve_irr_as_set_prefixes()
                 if (
                     "limit" in options
                     and options["limit"] is not None
@@ -44,8 +43,11 @@ class Command(BaseCommand):
                             options["limit"],
                         )
                         prefixes["ipv4"] = []
-            except ValueError:
-                pass
+            except ValueError as e:
+                self.logger.warn(
+                    "Error fetching prefixes for as%s: %s", autonomous_system.asn, e
+                )
+                prefixes = dict(ipv6=[], ipv4=[])
 
             autonomous_system.prefixes = prefixes
             autonomous_system.save()

--- a/peering/management/commands/grab_prefixes.py
+++ b/peering/management/commands/grab_prefixes.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                     )
                     prefixes = dict(ipv6=[], ipv4=[])
                 else:
-                    raise(e)
+                    raise (e)
 
             autonomous_system.prefixes = prefixes
             autonomous_system.save()


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
If bgpq3 errors out for some reason, then the entire grab_prefixes command will stop. 
You may want to ignore transient errors and not have the entire process stop
Added a `--ignore-errors` option so the loop will continue processing all the ASN's

<!--
    Please include a summary of the proposed changes below.
-->
