### PR TITLE
Display service_reference via API

### DIFF
--- a/peering/api/serializers.py
+++ b/peering/api/serializers.py
@@ -145,6 +145,7 @@ class DirectPeeringSessionSerializer(
         model = DirectPeeringSession
         fields = [
             "id",
+            "service_reference",
             "local_autonomous_system",
             "local_ip_address",
             "autonomous_system",
@@ -214,6 +215,7 @@ class InternetExchangePeeringSessionSerializer(
         model = InternetExchangePeeringSession
         fields = [
             "id",
+            "service_reference",
             "autonomous_system",
             "ixp_connection",
             "ip_address",


### PR DESCRIPTION
### Fixes:
Return `service_reference` in the API calls for `/api/peering/direct-peering-sessions/` and `/api/peering/internet-exchange-peering-sessions/`
