### PR TITLE
Fix or comment broken documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ Leveraging the new `Email` object, the `subject` field has been added to allow u
 
 Autonomous System contacts can be synchronized from PeeringDB to use them as recipients for e-mails. Some PeeringDB contacts are hidden and cannot be synchronized if the `PEERINGDB_USERNAME` and `PEERINGDB_PASSWORD` are not set in the configuration. For all contacts to be synchronized, clearing the cache then re-synchronizing with PeeringDB is required.
 
+[//]: # (The links in the next line are broken.)
 When a contact is available for an Autonomous System a `Send E-mail` tab will be available from the AS view. An e-mail template has to be selected along with a contact to send the e-mail to. E-mail templates can be written following [this section](https://peering-manager.readthedocs.io/en/latest/templates/#e-mail) of the documentation. An example is also [available](https://peering-manager.readthedocs.io/en/latest/templates/peering-request-email/).
 
 ### Enhancements

--- a/peering/forms.py
+++ b/peering/forms.py
@@ -55,7 +55,7 @@ class TemplateField(TextareaField):
         label = kwargs.pop("label", "Template")
         super().__init__(
             label=label,
-            help_text='<i class="fas fa-info-circle"></i> <a href="https://peering-manager.readthedocs.io/en/latest/templates/" target="_blank">Jinja2 template</a> syntax is supported',
+            help_text='<i class="fas fa-info-circle"></i> <a href="https://peering-manager.readthedocs.io/en/latest/templating/" target="_blank">Jinja2 template</a> syntax is supported',
             *args,
             **kwargs,
         )
@@ -400,7 +400,7 @@ class DirectPeeringSessionFilterForm(BootstrapMixin, forms.Form):
 
 class EmailForm(BootstrapMixin, forms.ModelForm):
     subject = forms.CharField(
-        help_text='<i class="fas fa-info-circle"></i> <a href="https://peering-manager.readthedocs.io/en/latest/templates/" target="_blank">Jinja2 template</a> syntax is supported'
+        help_text='<i class="fas fa-info-circle"></i> <a href="https://peering-manager.readthedocs.io/en/latest/templating/" target="_blank">Jinja2 template</a> syntax is supported'
     )
     template = TemplateField(label="Body")
     comments = CommentField()

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -149,7 +149,7 @@
             <p>{% now 'Y-m-d H:i:s T' %}</p>
             <p>
               <i class="fas fa-fw fa-cloud"></i> <a href="{% url 'api-root' %}">API</a> &middot;
-              <i class="fas fa-fw fa-book"></i> <a href="http://peering-manager.readthedocs.io/">Docs</a> &middot;
+              <i class="fas fa-fw fa-book"></i> <a href="http://peering-manager.readthedocs.io/en/{{ settings.VERSION | doc_version }}">Docs</a> &middot;
               <i class="fab fa-fw fa-github"></i> <a href="https://github.com/peering-manager/peering-manager">GitHub</a>
             </p>
         </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,7 +6,7 @@
       <div class="alert alert-info text-center" role="alert">
         <i class="fas fa-info-circle"></i>
         A new release is available: <a href="{{ new_release.url }}">Peering Manager v{{ new_release.version }}</a> |
-        <a href="https://peering-manager.readthedocs.io/en/latest/setup/upgrading/">Upgrade instructions</a>
+        <a href="https://peering-manager.readthedocs.io/en/{{ new_release.version }}/setup/upgrading/">Upgrade instructions</a>
       </div>
       {% endif %}
 {% endblock %}

--- a/templates/peering/configuration/details.html
+++ b/templates/peering/configuration/details.html
@@ -42,7 +42,7 @@
       <pre class="pre-scrollable">{{ instance.template }}</pre>
       <div class="card-footer">
         <i class="fa fa-info-circle"></i>
-        <a href="https://peering-manager.readthedocs.io/en/latest/templates/" target="_blank">Jinja2 template</a> syntax
+        <a href="https://peering-manager.readthedocs.io/en/{{ settings.VERSION | doc_version }}/templating/" target="_blank">Jinja2 template</a> syntax
       </div>
     </div>
   </div>

--- a/templates/peering/email/details.html
+++ b/templates/peering/email/details.html
@@ -21,7 +21,7 @@
       <pre class="pre-scrollable">{{ instance.subject }}</pre>
       <div class="card-footer">
         <i class="fa fa-info-circle"></i>
-        <a href="https://peering-manager.readthedocs.io/en/latest/templates/" target="_blank">Jinja2 template</a> syntax
+        <a href="https://peering-manager.readthedocs.io/en/{{ settings.VERSION | doc_version }}/templating/" target="_blank">Jinja2 template</a> syntax
       </div>
     </div>
   </div>
@@ -46,7 +46,7 @@
       <pre class="pre-scrollable">{{ instance.template }}</pre>
       <div class="card-footer">
         <i class="fa fa-info-circle"></i>
-        <a href="https://peering-manager.readthedocs.io/en/latest/templates/" target="_blank">Jinja2 template</a> syntax
+        <a href="https://peering-manager.readthedocs.io/en/{{ settings.VERSION | doc_version }}/templating/" target="_blank">Jinja2 template</a> syntax
       </div>
     </div>
   </div>

--- a/utils/templatetags/helpers.py
+++ b/utils/templatetags/helpers.py
@@ -195,3 +195,11 @@ def missing_sessions(context, autonomous_system):
         if autonomous_system.get_missing_peering_sessions(context["context_as"], i):
             return True
     return False
+
+
+@register.filter
+def doc_version(version):
+    if "-dev" in version:
+        return "latest"
+    else:
+        return version


### PR DESCRIPTION
I have stumbled upon some broken links to documentation in the code.

Some discussion points:
1. Maybe we don't want to let documentation links show to latest but to the corresponding release?
2. Should we do the same to the line I commented in the changelog? As far as I can see, the documentation for that old release does not exist any more?