### PR TITLE
Set up a configurable cache time around the results of get_bgp_neighbors_detail()

### DIFF
--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -45,6 +45,17 @@ them. Setting the value to 0 will disable the use of the caching functionality.
 
 ---
 
+## CACHE_BGP_DETAIL_TIMEOUT
+
+Default: 900
+
+The number of seconds to retain cache entries for NAPALM BGP details data
+before automatically invalidating them. It improves the speed of operations
+such as polling session statuses. Setting the value to 0 will disable the use
+of the caching functionality.
+
+---
+
 ## CHANGELOG_RETENTION
 
 Default: `90`

--- a/peering/models/models.py
+++ b/peering/models/models.py
@@ -1611,7 +1611,7 @@ class Router(ChangeLoggedModel, TaggableModel):
         will be empty.
         """
 
-        @cached_as(self, timeout=settings.CACHEOPS_BGP_DETAIL_TIMEOUT)
+        @cached_as(self, timeout=settings.CACHE_BGP_DETAIL_TIMEOUT)
         def _get_bgp_neighbors_detail():
             if self.use_netbox:
                 return self.get_netbox_bgp_neighbors_detail(ip_address=ip_address)

--- a/peering/models/models.py
+++ b/peering/models/models.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 
 import napalm
+from cacheops import cached_as
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Q
@@ -341,12 +342,7 @@ class AutonomousSystem(ChangeLoggedModel, TaggableModel, PolicyMixin):
                     )
                 )
             else:
-                addresses.append(
-                    (
-                        email,
-                        email,
-                    )
-                )
+                addresses.append((email, email,))
         return addresses
 
     def get_email_context(self):
@@ -1609,10 +1605,15 @@ class Router(ChangeLoggedModel, TaggableModel):
         If an error occurs or no BGP neighbors can be found, the returned list
         will be empty.
         """
-        if self.use_netbox:
-            return self.get_netbox_bgp_neighbors_detail(ip_address=ip_address)
-        else:
-            return self.get_napalm_bgp_neighbors_detail(ip_address=ip_address)
+
+        @cached_as(self, timeout=settings.CACHEOPS_BGP_DETAIL_TIMEOUT)
+        def _get_bgp_neighbors_detail():
+            if self.use_netbox:
+                return self.get_netbox_bgp_neighbors_detail(ip_address=ip_address)
+            else:
+                return self.get_napalm_bgp_neighbors_detail(ip_address=ip_address)
+
+        return _get_bgp_neighbors_detail()
 
     def bgp_neighbors_detail_as_list(self, bgp_neighbors_detail):
         """

--- a/peering/models/models.py
+++ b/peering/models/models.py
@@ -342,7 +342,12 @@ class AutonomousSystem(ChangeLoggedModel, TaggableModel, PolicyMixin):
                     )
                 )
             else:
-                addresses.append((email, email,))
+                addresses.append(
+                    (
+                        email,
+                        email,
+                    )
+                )
         return addresses
 
     def get_email_context(self):

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -55,6 +55,7 @@ DEBUG = getattr(configuration, "DEBUG", False)
 LOGGING = getattr(configuration, "LOGGING", {})
 REDIS = getattr(configuration, "REDIS", {})
 CACHE_TIMEOUT = getattr(configuration, "CACHE_TIMEOUT", 0)
+CACHE_BGP_DETAIL_TIMEOUT = getattr(configuration, "CACHE_BGP_DETAIL_TIMEOUT", 900)
 CHANGELOG_RETENTION = getattr(configuration, "CHANGELOG_RETENTION", 90)
 LOGIN_REQUIRED = getattr(configuration, "LOGIN_REQUIRED", False)
 BANNER_LOGIN = getattr(configuration, "BANNER_LOGIN", "")
@@ -289,7 +290,6 @@ CACHEOPS = {
     "webhooks.*": {"ops": "all"},
 }
 CACHEOPS_DEGRADE_ON_FAILURE = True
-CACHEOPS_BGP_DETAIL_TIMEOUT = getattr(configuration, "CACHEOPS_BGP_DETAIL_TIMEOUT", 900)
 
 if TASKS_REDIS_USING_SENTINEL:
     RQ_PARAMS = {

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -289,6 +289,7 @@ CACHEOPS = {
     "webhooks.*": {"ops": "all"},
 }
 CACHEOPS_DEGRADE_ON_FAILURE = True
+CACHEOPS_BGP_DETAIL_TIMEOUT = getattr(configuration, "CACHEOPS_BGP_DETAIL_TIMEOUT", 900)
 
 if TASKS_REDIS_USING_SENTINEL:
     RQ_PARAMS = {


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes:
Issue #471. 

*  Cache the results of get_bgp_neighbors_detail()
* Add a `CACHEOPS_BGP_DETAIL_TIMEOUT` to settings to control the timeout. 
* Need to decide what a reasonable default value is here. 

<!--
    Please include a summary of the proposed changes below.
-->
