### PR TITLE
Fix typo in the template

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -91,7 +91,7 @@
                 <h5 class="list-group-item-heading">
                   <a href="{% url 'peering:routingpolicy_list' %}">Routing Policies</a>
                 </h5>
-                <p class="list-group-item-textn text-muted">Policies filtering adverised/received routes</p>
+                <p class="list-group-item-textn text-muted">Policies filtering advertised/received routes</p>
               </div>
               <div class="list-group-item">
                 <h1 class="display-4 float-right">{{ statistics.communities_count }}</h1>


### PR DESCRIPTION
### Fixes:

`adverised` vs `advertised`
