### PR TITLE
Changing NGINX Proxy Configuration in Documentation

### DIFF
--- a/docs/setup/4b-nginx.md
+++ b/docs/setup/4b-nginx.md
@@ -34,11 +34,10 @@ server {
 	server_name peering.example.com;
 
 	location / {
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwared-Proto $scheme;
 		proxy_pass http://127.0.0.1:8001;
-		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-Host $server_name;
+        	proxy_set_header X-Real-IP $remote_addr;
+        	proxy_set_header X-Forwarded-Proto $scheme;
 	}
 
 	location /static {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes: #499

<!--
    Please include a summary of the proposed changes below.
-->

With this configuration within nginx, http and https links within
the API are rendered correctly when you are using https for the virtualhost.
With the former ones, https usage in API link is broken.
