### PR TITLE
Loop over connections instead of routers

### DIFF
--- a/peering/models/models.py
+++ b/peering/models/models.py
@@ -728,12 +728,12 @@ class InternetExchange(AbstractGroup):
     @transaction.atomic
     def poll_peering_sessions(self):
         # Get connections to this IXP
-        connections = self.get_connections()
+        connections = self.get_connections().filter(router__isnull=False)
 
         # Check if we are able to get BGP details
         log = 'ignoring session states on {}, reason: "{}"'
         if connections.count() < 0:
-            log = log.format(self.name.lower(), "no routers connected")
+            log = log.format(self.name.lower(), "no connections with routers")
         elif not self.check_bgp_session_states:
             log = log.format(self.name.lower(), "check disabled")
         else:


### PR DESCRIPTION
This doesn't fix a new problem, but it's an alternate fix to #501 that I think is a bit cleaner. Instead of looping over the IX's routers and then trying to use the neighbor IPs to find the connection back to the IX, this approach loops over the IX's connections so the current connection is available when performing the session lookup.

This also avoids instantiating ipaddress objects for each neighbor and the problem of pre-1.4.5 connection addresses having /32 or /128 subnets.