### PR TITLE
workaround runtime import IX when PDB data has connections with no IPs

### DIFF
--- a/net/models.py
+++ b/net/models.py
@@ -87,7 +87,7 @@ class Connection(ChangeLoggedModel, TaggableModel):
 
         # If data imported from PDB is null+null then there the query
         # could return many objects and will runtime.
-        if self.ipv4_address is None and self.ipv4_address is None:
+        if self.ipv4_address is None and self.ipv6_address is None:
             return None
 
         try:

--- a/net/models.py
+++ b/net/models.py
@@ -84,6 +84,12 @@ class Connection(ChangeLoggedModel, TaggableModel):
         any other cases `None` will be returned. The value will also be saved in the
         corresponding field of the model.
         """
+
+        # If data imported from PDB is null+null then there the query
+        # could return many objects and will runtime.
+        if self.ipv4_address is None and self.ipv4_address is None:
+            return None
+
         try:
             netixlan = NetworkIXLan.objects.get(
                 ipaddr6=self.ipv6_address, ipaddr4=self.ipv4_address

--- a/peering/views.py
+++ b/peering/views.py
@@ -621,6 +621,9 @@ class InternetExchangePeeringDBImport(PermissionRequiredMixin, ReturnURLMixin, V
             )
 
             for connection in connections:
+                if not connection.cidr4 and not connection.cidr6:
+                    # PeeringDB has no address data; skip!
+                    continue
                 Connection.objects.create(
                     peeringdb_netixlan=connection,
                     internet_exchange_point=i,

--- a/peeringdb/models.py
+++ b/peeringdb/models.py
@@ -476,11 +476,17 @@ class NetworkIXLan(models.Model):
 
     @property
     def cidr4(self):
-        return self.cidr(address_family=4)
+        try:
+            return self.cidr(address_family=4)
+        except ValueError:
+            return None
 
     @property
     def cidr6(self):
-        return self.cidr(address_family=6)
+        try:
+            return self.cidr(address_family=6)
+        except ValueError:
+            return None
 
     def get_ixlan_prefix(self, address_family=0):
         """


### PR DESCRIPTION
When importing "LINX Manchester" as AS41495, we found that our ASN had two records in PeeringDB, one of which looked like stale data (though it could be an artefact of how we are a LINX ConneXions Partner and so have a port with no IP address, in addition to a VLAN within that port providing peering LAN services to our AS).

To confirm this issue we set our local instance of PM v1.6.0 to show this text for entries with no IPv4/IPv6 address:

<img width="887" alt="image" src="https://user-images.githubusercontent.com/9492487/156922415-2449df1c-9f26-4a4b-aa78-c148b255bc66.png">

### Fixes:

What I have done in this very small PR is to catch the ValueError and ensure `cidr4` and `cidr6` return `None` instead.  This at least allows the IXs to be imported, even if the IP addresses aren't there for these "ghost" connections:

<img width="882" alt="image" src="https://user-images.githubusercontent.com/9492487/156922517-1f3b3846-02b6-461f-9b23-f5431baa4897.png">
