### PR TITLE
Use of Django 4 and Python < 3.8 deprecation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,8 +22,6 @@ body:
       label: Python version
       description: What version of Python are you currently running?
       options:
-        - "3.6"
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
     strategy:
       matrix:
         toxenv:
-          - py36
-          - py37
           - py38
           - py39
           - py310

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,6 @@ jobs:
           - py39
           - py310
         include:
-          - toxenv: py36
-            python-version: "3.6"
-          - toxenv: py37
-            python-version: "3.7"
           - toxenv: py38
             python-version: "3.8"
           - toxenv: py39
@@ -67,7 +63,7 @@ jobs:
             python-version: "3.10"
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         ports:
           - 5432:5432
         env:
@@ -75,7 +71,7 @@ jobs:
           POSTGRES_USER: devbox
           POSTGRES_PASSWORD: devbox
       redis:
-        image: redis:6.0
+        image: redis:6
         ports:
           - 6379:6379
     steps:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ with a [PostgreSQL](https://www.postgresql.org) database,
 with some dependencies to run. For a complete list of requirements, see
 `requirements.txt`.
 
-Tested Python versions are 3.6, 3.7, 3.8, 3.9 and 3.10.
+Tested Python versions are 3.8, 3.9 and 3.10.
 
 The best way to start setting up this tool is to use **pip** within a
 **virtualenv**.

--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -14,6 +14,63 @@ BASE_PATH = "peering/"
 
 ---
 
+## CORS_ORIGIN_ALLOW_ALL
+
+Default: False
+
+If True, cross-origin resource sharing (CORS) requests will be accepted from
+all origins. If False, a whitelist will be used (see below).
+
+---
+
+## CORS_ORIGIN_WHITELIST
+
+## CORS_ORIGIN_REGEX_WHITELIST
+
+These settings specify a list of origins that are authorized to make
+cross-site API requests. Use `CORS_ORIGIN_WHITELIST` to define a list of exact
+hostnames, or `CORS_ORIGIN_REGEX_WHITELIST` to define a set of regular
+expressions. (These settings have no effect if `CORS_ORIGIN_ALLOW_ALL` is
+True.) For example:
+
+```python
+CORS_ORIGIN_WHITELIST = [
+    'https://example.com',
+]
+```
+
+---
+
+## CSRF_COOKIE_NAME
+
+Default: `csrftoken`
+
+The name of the cookie to use for the cross-site request forgery (CSRF)
+authentication token. See the
+[Django documentation](https://docs.djangoproject.com/en/stable/ref/settings/#csrf-cookie-name)
+for more detail.
+
+---
+
+## CSRF_TRUSTED_ORIGINS
+
+Default: `[]`
+
+Defines a list of trusted origins for unsafe (e.g. `POST`) requests. This is a
+pass-through to Django's
+[`CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS)
+setting. Note that each host listed must specify a scheme (e.g. `http://` or
+`https://).
+
+```python
+CSRF_TRUSTED_ORIGINS = (
+    'http://peering-manager.local',
+    'https://peering-manager.local',
+)
+```
+
+---
+
 ## USE_X_FORWARDED_HOST
 
 Default: `True`

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -84,8 +84,8 @@ $ python manage.py runserver
 Performing system checks...
 
 System check identified no issues (0 silenced).
-July 12, 2021 - 19:38:41
-Django version 3.2.5, using settings 'peering_manager.settings'
+May 29, 2022 - 11:22:19
+Django version 4.0.4, using settings 'peering_manager.settings'
 Starting development server at http://127.0.0.1:8000/
 Quit the server with CONTROL-C.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ framework. It runs as a WSGI service behind your choice of HTTP server.
 | HTTP Service | Apache 2 or nginx     |
 | WSGI Service | gunicorn or uWSGI     |
 | Application  | Django/Python         |
-| Database     | PostgreSQL 9.6+       |
-| Task queuing | Redis 4.0+            |
+| Database     | PostgreSQL 10+        |
+| Task queuing | Redis 6+              |
 
 ## Getting Started
 

--- a/docs/setup/1-postgresql.md
+++ b/docs/setup/1-postgresql.md
@@ -1,5 +1,5 @@
 # PostgreSQL
-Peering Manager requires a PostgreSQL (>= 9.6) database to store data. This can be
+Peering Manager requires a PostgreSQL (>= 10) database to store data. This can be
 hosted locally or on a remote server. Please note that Peering Manager does not
 support any other database backends as it uses some specific features of
 PostgreSQL.
@@ -46,7 +46,7 @@ username and password for authentication.
 
 ```no-highlight
 # sudo -u postgres psql
-psql (9.6.3)
+psql (10.21)
 Type "help" for help.
 
 postgres=# CREATE DATABASE peering_manager ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8' TEMPLATE template0;

--- a/docs/setup/2-redis.md
+++ b/docs/setup/2-redis.md
@@ -6,7 +6,7 @@ Manager for caching and queuing.
 This section explains the installation and configuration of a local Redis
 service. If you already have a Redis service in place, you can skip this step.
 
-Redis version 4.0+ is required so you may wish to check that your distribution
+Redis version 6+ is required so you may wish to check that your distribution
 can provide a compatible version.
 
 ## Installation

--- a/docs/setup/3-peering-manager.md
+++ b/docs/setup/3-peering-manager.md
@@ -4,7 +4,7 @@
 
 First we need a proper text editor, Git and Python. We will use Git to get the
 code, and Python to run it. Peering Manager is mostly tested with Python
-version 3 so we will setup the machine with this version.
+version 3 (3.8 minimum) so we will setup the machine with this version.
 
 === "Debian 10 / 11"
 	```no-highlight
@@ -89,7 +89,7 @@ and HTTP services to run under this account.
 ## Set Up Python Environment
 
 First create a Python
-[virtual environment](https://docs.python.org/3.6/tutorial/venv.html) to ensure
+[virtual environment](https://docs.python.org/3.8/tutorial/venv.html) to ensure
 Peering Manager's required packages don't conflict with anything in the system.
 This will create a directory named `venv` in the Peering Manager root
 directory.
@@ -224,8 +224,8 @@ And now we can start testing the setup.
 Performing system checks...
 
 System check identified no issues (0 silenced).
-September 27, 2017 - 22:33:30
-Django version 1.11.5, using settings 'peering_manager.settings'
+May 29, 2022 - 11:22:19
+Django version 4.0.4, using settings 'peering_manager.settings'
 Starting development server at http://0.0.0.0:8000/
 Quit the server with CONTROL-C.
 ```

--- a/docs/setup/5-logging.md
+++ b/docs/setup/5-logging.md
@@ -15,6 +15,7 @@ loggers are provided:
 * `peering.manager.peering`: logging internal models and views
 * `peering.manager.peeringdb`: logging actions related to PeeringDB
 * `peering.manager.releases`: logging new release monitoring
+* `peering.manager.users`: logging user and authentication views
 
 To adjust the logging configuration to your needs, you probably want to read
 [Django's documentation](https://docs.djangoproject.com/en/stable/topics/logging/)

--- a/extras/__init__.py
+++ b/extras/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "extras.apps.ExtrasConfig"

--- a/peering/__init__.py
+++ b/peering/__init__.py
@@ -4,8 +4,6 @@ import subprocess
 
 from django.conf import settings
 
-default_app_config = "peering.apps.PeeringConfig"
-
 
 def call_irr_as_set_resolver(irr_as_set, address_family=6):
     """

--- a/peering/migrations/0001_v1.0.0.py
+++ b/peering/migrations/0001_v1.0.0.py
@@ -433,16 +433,16 @@ class Migration(migrations.Migration):
                     "export_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="internetexchange_export_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_export_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (
                     "import_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="internetexchange_import_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_import_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
             ],
@@ -515,16 +515,16 @@ class Migration(migrations.Migration):
                     "export_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="directpeeringsession_export_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_export_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (
                     "import_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="directpeeringsession_import_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_import_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
             ],
@@ -591,16 +591,16 @@ class Migration(migrations.Migration):
                     "export_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="internetexchangepeeringsession_export_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_export_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (
                     "import_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="internetexchangepeeringsession_import_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_import_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
             ],
@@ -865,8 +865,8 @@ class Migration(migrations.Migration):
             name="export_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="autonomoussystem_export_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_export_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -874,8 +874,8 @@ class Migration(migrations.Migration):
             name="import_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="autonomoussystem_import_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_import_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.CreateModel(
@@ -903,16 +903,16 @@ class Migration(migrations.Migration):
                     "export_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="bgpgroup_export_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_export_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (
                     "import_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="bgpgroup_import_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_import_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (

--- a/peering/migrations/0022_auto_20181116_2226.py
+++ b/peering/migrations/0022_auto_20181116_2226.py
@@ -31,8 +31,8 @@ class Migration(migrations.Migration):
             name="export_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="directpeeringsession_export_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_export_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -40,8 +40,8 @@ class Migration(migrations.Migration):
             name="import_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="directpeeringsession_import_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_import_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -49,8 +49,8 @@ class Migration(migrations.Migration):
             name="export_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="internetexchange_export_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_export_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -58,8 +58,8 @@ class Migration(migrations.Migration):
             name="import_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="internetexchange_import_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_import_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -67,8 +67,8 @@ class Migration(migrations.Migration):
             name="export_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="internetexchangepeeringsession_export_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_export_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -76,8 +76,8 @@ class Migration(migrations.Migration):
             name="import_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="internetexchangepeeringsession_import_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_import_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
     ]

--- a/peering/migrations/0044_auto_20190513_2153.py
+++ b/peering/migrations/0044_auto_20190513_2153.py
@@ -13,8 +13,8 @@ class Migration(migrations.Migration):
             name="export_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="autonomoussystem_export_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_export_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
         migrations.AddField(
@@ -22,8 +22,8 @@ class Migration(migrations.Migration):
             name="import_routing_policies",
             field=models.ManyToManyField(
                 blank=True,
-                related_name="autonomoussystem_import_routing_policies",
-                to="peering.RoutingPolicy",
+                related_name="%(class)s_import_routing_policies",
+                to="peering.routingpolicy",
             ),
         ),
     ]

--- a/peering/migrations/0045_auto_20190514_2308.py
+++ b/peering/migrations/0045_auto_20190514_2308.py
@@ -34,16 +34,16 @@ class Migration(migrations.Migration):
                     "export_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="bgpgroup_export_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_export_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (
                     "import_routing_policies",
                     models.ManyToManyField(
                         blank=True,
-                        related_name="bgpgroup_import_routing_policies",
-                        to="peering.RoutingPolicy",
+                        related_name="%(class)s_import_routing_policies",
+                        to="peering.routingpolicy",
                     ),
                 ),
                 (

--- a/peering/migrations/0065_auto_20201025_2137.py
+++ b/peering/migrations/0065_auto_20201025_2137.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 null=True,
                 on_delete=django.db.models.deletion.CASCADE,
-                related_name="directpeeringsession_local_autonomous_system",
+                related_name="%(class)s_local_autonomous_system",
                 to="peering.autonomoussystem",
             ),
         ),

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -21,9 +21,9 @@ DOCS_DIR = BASE_DIR / "docs"
 VERSION = "v1.6.3-dev"
 
 major, minor, _ = platform.python_version_tuple()
-if (int(major), int(minor)) < (3, 6):
+if (int(major), int(minor)) < (3, 8):
     raise RuntimeError(
-        f"Peering Manager requires Python 3.6 or higher (current: Python {platform.python_version()})"
+        f"Peering Manager requires Python 3.8 or higher (current: Python {platform.python_version()})"
     )
 
 try:

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -50,11 +50,14 @@ MY_ASN = getattr(configuration, "MY_ASN", None)
 if MY_ASN:
     warnings.warn("MY_ASN is no longer supported and will be removed in 2.0.")
 
-CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
-
 BASE_PATH = getattr(configuration, "BASE_PATH", "")
 if BASE_PATH:
     BASE_PATH = BASE_PATH.strip("/") + "/"  # Enforce trailing slash only
+CORS_ORIGIN_ALLOW_ALL = getattr(configuration, "CORS_ORIGIN_ALLOW_ALL", False)
+CORS_ORIGIN_REGEX_WHITELIST = getattr(configuration, "CORS_ORIGIN_REGEX_WHITELIST", [])
+CORS_ORIGIN_WHITELIST = getattr(configuration, "CORS_ORIGIN_WHITELIST", [])
+CSRF_COOKIE_NAME = getattr(configuration, "CSRF_COOKIE_NAME", "csrftoken")
+CSRF_TRUSTED_ORIGINS = getattr(configuration, "CSRF_TRUSTED_ORIGINS", [])
 DEBUG = getattr(configuration, "DEBUG", False)
 LOGGING = getattr(configuration, "LOGGING", {})
 REDIS = getattr(configuration, "REDIS", {})

--- a/peering_manager/tests/test_jinja2.py
+++ b/peering_manager/tests/test_jinja2.py
@@ -377,16 +377,16 @@ class Jinja2FilterTestCase(TestCase):
         main = Configuration.objects.create(
             name="main", template="{% include_configuration 'test' %}"
         )
-        self.assertEquals("this is a test", main.render({}))
+        self.assertEqual("this is a test", main.render({}))
         main.template = "{% include 'configuration::test' %}"
         main.save()
-        self.assertEquals("this is a test", main.render({}))
+        self.assertEqual("this is a test", main.render({}))
 
         Email.objects.create(name="test", subject="test", template="this is a test")
         main = Email.objects.create(
             name="main", subject="main", template="{% include_email 'test' %}"
         )
-        self.assertEquals(("main", "this is a test"), main.render({}))
+        self.assertEqual(("main", "this is a test"), main.render({}))
         main.template = "{% include 'email::test' %}"
         main.save()
-        self.assertEquals(("main", "this is a test"), main.render({}))
+        self.assertEqual(("main", "this is a test"), main.render({}))

--- a/peering_manager/views/generics.py
+++ b/peering_manager/views/generics.py
@@ -15,7 +15,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.html import escape
-from django.utils.http import is_safe_url
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 
@@ -57,11 +56,9 @@ class GetReturnURLMixin(object):
     def get_return_url(self, request, instance=None):
         # Check if `return_url` was specified as a query parameter or form
         # data, use this URL only if it's safe
-        query_param = request.GET.get("return_url") or request.POST.get("return_url")
-        if query_param and is_safe_url(
-            url=query_param, allowed_hosts=request.get_host()
-        ):
-            return query_param
+        return_url = request.GET.get("return_url") or request.POST.get("return_url")
+        if return_url and return_url.startswith("/"):
+            return return_url
 
         # Check if the object being modified (if any) has an absolute URL
         if (
@@ -425,9 +422,7 @@ class ObjectDeleteView(GetReturnURLMixin, PermissionRequiredMixin, View):
             messages.success(request, msg)
 
             return_url = form.cleaned_data.get("return_url")
-            if return_url is not None and is_safe_url(
-                url=return_url, allowed_hosts=request.get_host()
-            ):
+            if return_url and return_url.startswith("/"):
                 return redirect(return_url)
             else:
                 return redirect(self.get_return_url(request, instance=o))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2,<3.3
+Django>=4.0,<4.1
 djangorestframework==3.13.1
 django-cacheops==6.0
 django-debug-toolbar==3.2.4
@@ -9,7 +9,7 @@ django-rq==2.5.1
 django-tables2==2.4.1
 django-taggit==3.0.0
 drf-spectacular==0.22.1
-Jinja2>=3.0,<3.1 # 3.1 does not support Python 3.6
+Jinja2>=3.1.2
 Markdown==3.3.7
 napalm==3.4.1
 packaging==21.3

--- a/templates/includes/pagination.html
+++ b/templates/includes/pagination.html
@@ -10,7 +10,7 @@
         {% endif %}
         {% for p in page.smart_pages %}
         {% if p %}
-        <li class="page-item{% ifequal page.number p %} active{% endifequal %}"><a class="page-link" href="{% querystring request page=p %}">{{ p }}</a></li>
+        <li class="page-item{% if page.number == p %} active{% endif %}"><a class="page-link" href="{% querystring request page=p %}">{{ p }}</a></li>
         {% else %}
         <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
         {% endif %}

--- a/templates/users/_user.html
+++ b/templates/users/_user.html
@@ -4,12 +4,12 @@
       <div class="row">
         <div class="col-md-2">
           <div class="nav flex-column nav-pills" role="tablist" aria-orientation="vertical">
-            <a class="nav-link {% ifequal active_tab "profile" %} active{% endifequal %}" role="tab" href="{% url 'users:profile' %}">Profile</a>
-            <a class="nav-link {% ifequal active_tab "preferences" %} active{% endifequal %}" role="tab" href="{% url 'users:preferences' %}">Preferences</a>
+            <a class="nav-link {% if active_tab == "profile" %} active{% endif %}" role="tab" href="{% url 'users:profile' %}">Profile</a>
+            <a class="nav-link {% if active_tab == "preferences" %} active{% endif %}" role="tab" href="{% url 'users:preferences' %}">Preferences</a>
             {% if not request.user.ldap_username %}
-            <a class="nav-link {% ifequal active_tab "password" %} active{% endifequal %}" role="tab" href="{% url 'users:change_password' %}">Change Password</a>
+            <a class="nav-link {% if active_tab == "password" %} active{% endif %}" role="tab" href="{% url 'users:change_password' %}">Change Password</a>
             {% endif %}
-            <a class="nav-link {% ifequal active_tab "api_tokens" %} active{% endifequal %}" role="tab" href="{% url 'users:token_list' %}">API Tokens</a>
+            <a class="nav-link {% if active_tab == "api_tokens" %} active{% endif %}" role="tab" href="{% url 'users:token_list' %}">API Tokens</a>
           </div>
         </div>
         <div class="col-md-8">

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py36,py37,py38,py39,py310
+envlist = py38,py39,py310
 
 [testenv]
 whitelist_externals = cp

--- a/utils/migrations/0001_v1.0.0.py
+++ b/utils/migrations/0001_v1.0.0.py
@@ -138,17 +138,17 @@ class Migration(migrations.Migration):
                     "content_type",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="utils_taggeditem_tagged_items",
-                        to="contenttypes.ContentType",
-                        verbose_name="Content type",
+                        related_name="%(app_label)s_%(class)s_tagged_items",
+                        to="contenttypes.contenttype",
+                        verbose_name="content type",
                     ),
                 ),
                 (
                     "tag",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="utils_taggeditem_items",
-                        to="utils.Tag",
+                        related_name="%(app_label)s_%(class)s_items",
+                        to="utils.tag",
                     ),
                 ),
             ],

--- a/utils/migrations/0005_tag_taggeditem.py
+++ b/utils/migrations/0005_tag_taggeditem.py
@@ -7,7 +7,6 @@ import utils.forms.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
         ("utils", "0004_auto_20181208_2202"),
@@ -64,17 +63,17 @@ class Migration(migrations.Migration):
                     "content_type",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="utils_taggeditem_tagged_items",
-                        to="contenttypes.ContentType",
-                        verbose_name="Content type",
+                        related_name="%(app_label)s_%(class)s_tagged_items",
+                        to="contenttypes.contenttype",
+                        verbose_name="content type",
                     ),
                 ),
                 (
                     "tag",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="utils_taggeditem_items",
-                        to="utils.Tag",
+                        related_name="%(app_label)s_%(class)s_items",
+                        to="utils.tag",
                     ),
                 ),
             ],

--- a/utils/migrations/0006_auto_20200626_2340.py
+++ b/utils/migrations/0006_auto_20200626_2340.py
@@ -27,8 +27,8 @@ class Migration(migrations.Migration):
             name="content_type",
             field=models.ForeignKey(
                 on_delete=django.db.models.deletion.CASCADE,
-                related_name="utils_taggeditem_tagged_items",
-                to="contenttypes.ContentType",
+                related_name="%(app_label)s_%(class)s_tagged_items",
+                to="contenttypes.contenttype",
                 verbose_name="content type",
             ),
         ),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->

Closes #532

* Bumps Django to 4.0
* Tweak old migrations to avoid introducing [no-op migrations](https://docs.djangoproject.com/en/4.0/releases/4.0/#migrations-autodetector-changes)
* Remove dependency on `is_safe_url()` function