### PR TITLE
Docs: hotfix: replace fqdn with generic variable

### DIFF
--- a/docs/models/extras/exporttemplate.md
+++ b/docs/models/extras/exporttemplate.md
@@ -32,7 +32,7 @@ CURL_OPTS='--silent'
 TMP_FILE="/tmp/librenms_bgp_sessions_$(date --utc +%s).json"
 
 curl ${CURL_OPTS} --header "X-Auth-Token: ${LIBRENMS_TOKEN}" \
-  "https://nms.kviknet.dk/api/v0/bgp" > ${TMP_FILE}
+  "https://${LIBRENMS_FQDN}/api/v0/bgp" > ${TMP_FILE}
 
 {%- for session in dataset %}
 
@@ -61,7 +61,7 @@ if [ $(echo -n ${session_id} | wc -l) ]; then
   --data "{
     \"bgp_descr\": \"$(echo -n ${bgp_description})\"
   }" \
-  "https://nms.kviknet.dk/api/v0/bgp/${session_id}"
+  "https://${LIBRENMS_FQDN}/api/v0/bgp/${session_id}"
 
 fi
 
@@ -70,10 +70,10 @@ fi
 
 Will generate a complete bash shell script that can be run to update BGP Peer
 descriptions in LibreNMS. The script assumes the LibreNMS token is provided as
-an environment variable, `LIBRENMS_TOKEN`. Peering Manager Object Type used for
-this template is `peering | internet exchange peering session`. Assumes `jq`,
-and `curl` are installed on the system. ([community.librenms.org][0],
-[github.com][1]).
+an environment variable, `LIBRENMS_TOKEN`. And the Domain Name as
+`LIBRENMS_FQDN`. Peering Manager Object Type used for this template is `peering
+| internet exchange peering session`. Assumes `jq`, and `curl` are installed on
+the system. ([community.librenms.org][0], [github.com][1]).
 
 [0]: https://community.librenms.org/t/bgp-peer-description-on-routing-page-complete/3337
 [1]: https://github.com/librenms/librenms/pull/9165


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes:

- Replace fqdn with generic environment variable