### PR TITLE
example to allow UPN logins

### DIFF
--- a/docs/setup/6a-ldap.md
+++ b/docs/setup/6a-ldap.md
@@ -60,6 +60,10 @@ AUTH_LDAP_BIND_PASSWORD = "thisisnotasecurepassword"
 When using Windows Server 2012, `AUTH_LDAP_USER_DN_TEMPLATE` should be set to
 `None`.
 
+When authenticating against MS Active Directory, you may want to change the
+LDAP search string to `"(|(sAMAccountName=%(user)s)(userPrincipalName=%(user)s))"`
+so that users can log in with their userid or their UPN in hybrid environments.
+
 ```python
 from django_auth_ldap.config import LDAPSearch
 


### PR DESCRIPTION
Provided an example LDAP search string to allow UPN logins as well as Userid logins.

<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
New information, not a fix.