### PR TITLE
Docs: Include information to have gunicorn listen on IPv6 ::1

### DIFF
--- a/docs/setup/3-peering-manager.md
+++ b/docs/setup/3-peering-manager.md
@@ -252,6 +252,11 @@ Before we can deliver Peering Manager with our web server of choice, we have to 
 	the pythonpath variable if needed. Note that some tasks such as importing
 	existing peering sessions or generating prefix lists can take a lot of time to
 	complete so setting a timeout greater than 30 seconds can be helpful.
+
+	!!! info "IPv6"
+		Replace `http://127.0.0.1:8001` with `http://[::1]:8001` if you have
+		configured gunicorn to listen on the IPv6 loopback address.
+
 	```no-highlight
 	bind = '127.0.0.1:8001'
 	workers = 5

--- a/docs/setup/4a-apache2.md
+++ b/docs/setup/4a-apache2.md
@@ -27,7 +27,12 @@ application server. On Debian, the configuration goes to
 `/etc/apache2/sites-available/peering-manager.conf`, on CentOS to
 `/etc/httpd/conf.d/peering-manager.conf`.
 
+!!! info "IPv6"
+	Replace `http://127.0.0.1:8001` with `http://[::1]:8001` if you have
+	configured gunicorn to listen on the IPv6 loopback address.
+
 The content of the file can be something like this.
+
 ```no-highlight
 <VirtualHost *:80>
   ProxyPreserveHost On

--- a/docs/setup/4b-nginx.md
+++ b/docs/setup/4b-nginx.md
@@ -27,6 +27,9 @@ To serve the application, a new configuration file has to be created at
 	your configuration files.
 	It also places a default configuration there that you should remove.
 
+!!! info "IPv6"
+	Replace `http://127.0.0.1:8001` with `http://[::1]:8001` if you have
+	configured gunicorn to listen on the IPv6 loopback address.
 
 ```no-highlight
 server {


### PR DESCRIPTION
Update apache2, nginx, and gunicorn sections to mention how to have peering-manager run on the IPv6 loopback address instead of the IPv4 loopback address.