### PR TITLE
Use new NAPALM version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ drf-spectacular==0.26.2
 drf-spectacular-sidecar==2023.5.1
 Jinja2>=3.1.2
 Markdown==3.4.3
-napalm==4.0.0
+napalm==4.1.0
 packaging==23.1
 psycopg2-binary==2.9.6
 pyixapi==0.1.4


### PR DESCRIPTION


### Fixes:

Updates requirements.txt to use NAPALM version 4.1.0, which includes a fix for napalm-automation/napalm#1743, which in turn fixes #723.