### PR TITLE
Fix filtering on tag in TagColumn

### DIFF
--- a/templates/utils/templatetags/tag.html
+++ b/templates/utils/templatetags/tag.html
@@ -1,5 +1,5 @@
 {% load helpers %}
 
-{% if url_name %}<a href="{% url url_name %}?tag={{ tag.pk }}">{% endif %}
+{% if url_name %}<a href="{% url url_name %}?tag={{ tag.slug }}">{% endif %}
 <span class="badge" style="color: {{ tag.color|foreground_colour }}; background-color: #{{ tag.color }}">{{ tag }}</span>
 {% if url_name %}</a>{% endif %}


### PR DESCRIPTION
### Fixes:

Template-Tag 'Tag' does set get parameter tag to <tag.pk>
Filtering needs <tag.slug> to work as it seems to be intended.
This change fixes this behaviour.
