### PR TITLE
Update installation documentation for PostgreSQL 15

### DIFF
--- a/docs/setup/1-postgresql.md
+++ b/docs/setup/1-postgresql.md
@@ -55,6 +55,9 @@ postgres=# CREATE USER peering_manager WITH PASSWORD 'DoNotUseMe';
 CREATE ROLE
 postgres=# GRANT ALL PRIVILEGES ON DATABASE peering_manager TO peering_manager;
 GRANT
+-- If running PostgreSQL v15 or above the following two commands are also necessary:
+\connect peering_manager
+GRANT CREATE ON SCHEMA public TO peering_manager;
 postgres=# \q
 ```
 


### PR DESCRIPTION
When using PostgreSQL version 15 or above the initial database migration failes due to missing permissions.

This patch updates the installation documentation, adding the commands necessary.
