### PR TITLE
Add census report call on worker start

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -21,6 +21,26 @@ form. HTML is allowed.
 
 ---
 
+### CENSUS_REPORTING_ENABLED
+
+Default: `True`
+
+Enables anonymous census reporting. To opt out, set this to `False`.
+
+This data enables the project maintainer to estimate how many Peering Manager
+deployments exist and track adoption of new versions over times.
+
+Census reporting performs a single HTTP POST request each time a worker
+starts.
+
+The reported data includes:
+
+* Pseudorandom unique identifier
+* Peering Manager version
+* Python version
+
+---
+
 ## CHANGELOG_RETENTION
 
 Default: `90`


### PR DESCRIPTION
This PR implements a census report call via HTTP POST when a worker start.

Users can disable this reporting by setting `CENSUS_REPORTING_ENABLED` to `False` in the configuration file.