### PR TITLE
Fix migration dependencies of router move in peering app

### DIFF
--- a/peering/migrations/0102_move_router.py
+++ b/peering/migrations/0102_move_router.py
@@ -16,6 +16,7 @@ def update_content_types(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("devices", "0007_move_router"),
+        ("net", "0010_move_router"),
         ("peering", "0101_router_config_push_data_source"),
     ]
 


### PR DESCRIPTION
Fixes:
Closes https://github.com/peering-manager/peering-manager/issues/870

Migration dependency missing