### PR TITLE
Fix merged_communities on Session-Model for direct peering session

### DIFF
--- a/peering/models/abstracts.py
+++ b/peering/models/abstracts.py
@@ -231,9 +231,10 @@ class BGPSession(PrimaryModel, PolicyMixin):
         else:
             group = self.bgp_group
 
-        for c in group.communities.all():
-            if c not in merged:
-                merged.append(c)
+        if group:
+            for c in group.communities.all():
+                if c not in merged:
+                    merged.append(c)
 
         return merged
 


### PR DESCRIPTION
Fix merged_communities on Session-Model for direct peering session with bgp_group=null

### Fixes:

Closes #874