### PR TITLE
Log 500 for api views, on programming errors and on import errors

### DIFF
--- a/peering_manager/middleware.py
+++ b/peering_manager/middleware.py
@@ -8,13 +8,10 @@ from django.contrib.auth.middleware import (
     RemoteUserMiddleware as DjangoRemoteUserMiddleware,
 )
 from django.core.exceptions import ImproperlyConfigured
-from django.db import ProgrammingError
-from django.http import Http404, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 
 from core.context_managers import change_logging
-from utils.api import is_api_request, rest_api_server_error
-
-from .views import handler_500
+from utils.api import is_api_request
 
 __all__ = ("CoreMiddleware",)
 
@@ -60,30 +57,6 @@ class CoreMiddleware:
             response["API-Version"] = settings.REST_FRAMEWORK_VERSION
 
         return response
-
-    def process_exception(self, request, exception):
-        # Ignore exception catching if debug mode is on
-        if settings.DEBUG:
-            return None
-
-        # Lets Django handling 404
-        if isinstance(exception, Http404):
-            return None
-
-        # Handle exceptions that occur from REST API requests
-        if is_api_request(request):
-            return rest_api_server_error(request)
-
-        template = None
-        if isinstance(exception, ProgrammingError):
-            template = "errors/programming_error.html"
-        elif isinstance(exception, ImportError):
-            template = "errors/import_error.html"
-
-        if template:
-            return handler_500(request, template_name=template)
-
-        return None
 
 
 class RemoteUserMiddleware(DjangoRemoteUserMiddleware):

--- a/peering_manager/views/errors.py
+++ b/peering_manager/views/errors.py
@@ -2,11 +2,14 @@ import platform
 import sys
 
 from django.conf import settings
+from django.db import ProgrammingError
 from django.http import HttpResponseServerError
 from django.template import loader
 from django.template.exceptions import TemplateDoesNotExist
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME
+
+from utils.api import is_api_request, rest_api_server_error
 
 __all__ = ("handler_500", "trigger_500")
 
@@ -16,13 +19,22 @@ def handler_500(request, template_name=ERROR_500_TEMPLATE_NAME):
     """
     Custom 500 handler to provide additional context when rendering 500.html.
     """
+    if is_api_request(request):
+        return rest_api_server_error(request)
+
+    type_, error, _ = sys.exc_info()
+
+    if isinstance(error, ProgrammingError):
+        template_name = "errors/programming_error.html"
+    elif isinstance(error, ImportError):
+        template_name = "errors/import_error.html"
+
     try:
         template = loader.get_template(template_name)
     except TemplateDoesNotExist:
         return HttpResponseServerError(
             "<h1>Server Error (500)</h1>", content_type="text/html"
         )
-    type_, error, _ = sys.exc_info()
 
     return HttpResponseServerError(
         template.render(


### PR DESCRIPTION
Log 500 for api views, on programming errors and on import errors using djangos log_response mechanism

### Fixes:

#888