### PR TITLE
adding the communities column

### DIFF
--- a/peering/tables/tables.py
+++ b/peering/tables/tables.py
@@ -315,8 +315,9 @@ class RoutingPolicyTable(PeeringManagerTable):
             "name",
             "type",
             "weight",
+            "communities",
             "address_family",
             "tags",
             "actions",
         )
-        default_columns = ("pk", "name", "type", "weight", "address_family", "actions")
+        default_columns = ("pk", "name", "type", "weight", "communities", "address_family", "actions")


### PR DESCRIPTION
adding the communities column to show the attached communities to each peering policy in /routing-policies/ view

<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->


<!--
    Please include a summary of the proposed changes below.
-->
