### PR TITLE
handle null bgpq arguments

### DIFF
--- a/peering/functions.py
+++ b/peering/functions.py
@@ -19,20 +19,14 @@ def call_irr_as_set_resolver(irr_as_set, address_family=6):
     if not irr_as_set:
         return prefixes
 
-    # Call bgpq3 with arguments to get a JSON result
-    command = [
-        settings.BGPQ3_PATH,
-        "-h",
-        settings.BGPQ3_HOST,
-        "-S",
-        settings.BGPQ3_SOURCES,
-        f"-{address_family}",
-        "-A",
-        "-j",
-        "-l",
-        "prefix_list",
-        irr_as_set,
-    ]
+    # Call bgpq with arguments to get a JSON result;
+    # only include option if argument is not null
+    command = [ settings.BGPQ3_PATH, ]
+    if settings.BGPQ3_HOST and len(settings.BGPQ3_HOST) > 0:
+        command += [ "-h", settings.BGPQ3_HOST ]
+    if settings.BGPQ3_SOURCES and len(settings.BGPQ3_SOURCES) > 0:
+        command += [ "-S", settings.BGPQ3_SOURCES ]
+    command += [ f"-{address_family}", "-A", "-j", "-l", "prefix_list", irr_as_set ]
 
     # Merge user settings to command line right before the name of the prefix list
     if settings.BGPQ3_ARGS:

--- a/peering/functions.py
+++ b/peering/functions.py
@@ -21,12 +21,12 @@ def call_irr_as_set_resolver(irr_as_set, address_family=6):
 
     # Call bgpq with arguments to get a JSON result;
     # only include option if argument is not null
-    command = [ settings.BGPQ3_PATH, ]
+    command = [settings.BGPQ3_PATH]
     if settings.BGPQ3_HOST and len(settings.BGPQ3_HOST) > 0:
-        command += [ "-h", settings.BGPQ3_HOST ]
+        command += ["-h", settings.BGPQ3_HOST]
     if settings.BGPQ3_SOURCES and len(settings.BGPQ3_SOURCES) > 0:
-        command += [ "-S", settings.BGPQ3_SOURCES ]
-    command += [ f"-{address_family}", "-A", "-j", "-l", "prefix_list", irr_as_set ]
+        command += ["-S", settings.BGPQ3_SOURCES]
+    command += [f"-{address_family}", "-A", "-j", "-l", "prefix_list", irr_as_set]
 
     # Merge user settings to command line right before the name of the prefix list
     if settings.BGPQ3_ARGS:

--- a/peering/functions.py
+++ b/peering/functions.py
@@ -22,9 +22,9 @@ def call_irr_as_set_resolver(irr_as_set, address_family=6):
     # Call bgpq with arguments to get a JSON result;
     # only include option if argument is not null
     command = [settings.BGPQ3_PATH]
-    if settings.BGPQ3_HOST and len(settings.BGPQ3_HOST) > 0:
+    if settings.BGPQ3_HOST:
         command += ["-h", settings.BGPQ3_HOST]
-    if settings.BGPQ3_SOURCES and len(settings.BGPQ3_SOURCES) > 0:
+    if settings.BGPQ3_SOURCES:
         command += ["-S", settings.BGPQ3_SOURCES]
     command += [f"-{address_family}", "-A", "-j", "-l", "prefix_list", irr_as_set]
 


### PR DESCRIPTION
This change allows null/empty bgpq arguments by only including options for non-null arguments.

### Fixes:  issue #909 

The fix involves minor changes in peering/functions.py in how the bgpq command is constructed.