### PR TITLE
Keep IRR source in AS-SET for bgpq4

### DIFF
--- a/peering/models/__init__.py
+++ b/peering/models/__init__.py
@@ -357,12 +357,20 @@ class AutonomousSystem(PrimaryModel, PolicyMixin):
 
         try:
             # For each AS-SET try getting IPv6 and IPv4 prefixes
-            for as_set in as_sets:
+            for as_set_source, as_set in as_sets:
                 prefixes["ipv6"].extend(
-                    call_irr_as_set_resolver(as_set, address_family=6)
+                    call_irr_as_set_resolver(
+                        irr_as_set=as_set,
+                        irr_as_set_source=as_set_source,
+                        address_family=6,
+                    )
                 )
                 prefixes["ipv4"].extend(
-                    call_irr_as_set_resolver(as_set, address_family=4)
+                    call_irr_as_set_resolver(
+                        irr_as_set=as_set,
+                        irr_as_set_source=as_set_source,
+                        address_family=4,
+                    )
                 )
         except ValueError:
             # Error parsing AS-SETs

--- a/peering/tests/test_functions.py
+++ b/peering/tests/test_functions.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from ..functions import call_irr_as_set_resolver, parse_irr_as_set
 from .mocked_data import *
@@ -24,15 +24,31 @@ class IRRASSetFunctions(TestCase):
 
     def test_parse_irr_as_set(self):
         self.assertEqual(
-            ["AS201281:AS-MAZOYER-EU"],
-            parse_irr_as_set(201281, "RIPE::AS201281:AS-MAZOYER-EU"),
+            [("RIPE", "AS65535:AS-FOO")],
+            parse_irr_as_set(65535, "RIPE::AS65535:AS-FOO"),
         )
         self.assertEqual(
-            ["AS-HURRICANE", "AS-HURRICANEv6"],
-            parse_irr_as_set(6939, "AS-HURRICANE AS-HURRICANEv6"),
+            [("", "AS-BAR"), ("", "AS-BARv6")],
+            parse_irr_as_set(65535, "AS-BAR AS-BARv6"),
         )
         self.assertEqual(
-            ["AS51706:AS-MEMBERS"], parse_irr_as_set(51706, "AS51706:AS-MEMBERS")
+            [("", "AS65535:AS-MEMBERS")], parse_irr_as_set(65535, "AS65535:AS-MEMBERS")
         )
-        self.assertEqual(["AS3333"], parse_irr_as_set(3333, ""))
-        self.assertEqual(["AS3333"], parse_irr_as_set(3333, None))
+        self.assertEqual([("", "AS65535")], parse_irr_as_set(65535, ""))
+        self.assertEqual([("", "AS65535")], parse_irr_as_set(65535, None))
+
+    @override_settings(BGPQ3_PATH="/bin/bgpq4")
+    def test_parse_irr_as_set_bgpq4(self):
+        self.assertEqual(
+            [("RIPE", "RIPE::AS65535:AS-FOO")],
+            parse_irr_as_set(65535, "RIPE::AS65535:AS-FOO"),
+        )
+        self.assertEqual(
+            [("", "AS-BAR"), ("", "AS-BARv6")],
+            parse_irr_as_set(65535, "AS-BAR AS-BARv6"),
+        )
+        self.assertEqual(
+            [("", "AS65535:AS-MEMBERS")], parse_irr_as_set(65535, "AS65535:AS-MEMBERS")
+        )
+        self.assertEqual([("", "AS65535")], parse_irr_as_set(65535, ""))
+        self.assertEqual([("", "AS65535")], parse_irr_as_set(65535, None))


### PR DESCRIPTION
As bgpq4 is able to resolve an AS-SET even if it is prefixed with the IRR to use as source, we do not need to remove it. In fact, it's even better to keep it so bgpq4 can do its job properly.

In the case of bgpq3, we still remove the source from the AS-SET string and try to limit the source with it. If the parsed source is not in the sources specified in the settings, we will query all sources.
