### PR TITLE
Add support for listing BFD profiles of a router in templates

### DIFF
--- a/devices/models.py
+++ b/devices/models.py
@@ -5,10 +5,11 @@ import napalm
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models, transaction
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 
-from net.models import Connection
+from net.models import BFD, Connection
 from peering.enums import BGPState
 from peering.models import (
     AutonomousSystem,
@@ -294,6 +295,14 @@ class Router(PushedDataMixin, PrimaryModel):
                 internet_exchange_point=internet_exchange_point
             )
         )
+
+    def get_bfd_configs(self):
+        """
+        Returns all the BFDs that have at least one session configured on the router.
+        """
+        return BFD.objects.filter(
+            Q(directpeeringsession__router=self) | Q(internetexchangepeeringsession__ixp_connection__router=self)
+        ).distinct()
 
     def get_configuration_context(self):
         """

--- a/devices/models.py
+++ b/devices/models.py
@@ -301,7 +301,8 @@ class Router(PushedDataMixin, PrimaryModel):
         Returns all the BFDs that have at least one session configured on the router.
         """
         return BFD.objects.filter(
-            Q(directpeeringsession__router=self) | Q(internetexchangepeeringsession__ixp_connection__router=self)
+            Q(directpeeringsession__router=self)
+            | Q(internetexchangepeeringsession__ixp_connection__router=self)
         ).distinct()
 
     def get_configuration_context(self):

--- a/docs/templating/jinja2/filters.md
+++ b/docs/templating/jinja2/filters.md
@@ -413,6 +413,18 @@ Examples:
 {% for session in router | direct_peers('transit') %}
 ```
 
+## `bfds`
+
+For a router, fetches all BFD profiles used on this router.
+
+Examples:
+
+```no-highlight
+{%- for bfd in router | bfds %}
+...
+{%- endfor %}
+```
+
 ## `iter_export_policies` / `iter_import_policies`
 
 Fetches routing policies applied on export or on import of an object. Note

--- a/peering_manager/jinja2/filters.py
+++ b/peering_manager/jinja2/filters.py
@@ -808,6 +808,7 @@ def indent(value, n, chars=" ", reset=False):
 
     return r
 
+
 def bfds(value):
     """
     Returns all the BFDs that have at least one session configured on the router.
@@ -815,6 +816,7 @@ def bfds(value):
     if not isinstance(value, Router):
         raise ValueError("value is not a router")
     return value.get_bfd_configs()
+
 
 FILTER_DICT = {
     # Generics

--- a/peering_manager/jinja2/filters.py
+++ b/peering_manager/jinja2/filters.py
@@ -13,7 +13,7 @@ from devices.crypto.cisco import MAGIC as CISCO_MAGIC
 from devices.enums import DeviceStatus
 from devices.models import Router
 from net.enums import ConnectionStatus
-from net.models import Connection, BFD
+from net.models import Connection
 from peering.enums import BGPGroupStatus, BGPSessionStatus, IPFamily
 from peering.models import (
     AutonomousSystem,
@@ -814,10 +814,7 @@ def bfds(value):
     """
     if not isinstance(value, Router):
         raise ValueError("value is not a router")
-    r = BFD.objects.filter(
-        Q(directpeeringsession__router=value) | Q(internetexchangepeeringsession__ixp_connection__router=value)
-    ).distinct()
-    return r
+    return value.get_bfd_configs()
 
 FILTER_DICT = {
     # Generics

--- a/peering_manager/jinja2/filters.py
+++ b/peering_manager/jinja2/filters.py
@@ -814,7 +814,9 @@ def bfds(value):
     """
     if not isinstance(value, Router):
         raise ValueError("value is not a router")
-    r = BFD.objects.filter(Q(directpeeringsession__router=value) | Q(internetexchangepeeringsession__ixp_connection__router=value))
+    r = BFD.objects.filter(
+        Q(directpeeringsession__router=value) | Q(internetexchangepeeringsession__ixp_connection__router=value)
+    ).distinct()
     return r
 
 FILTER_DICT = {

--- a/peering_manager/jinja2/filters.py
+++ b/peering_manager/jinja2/filters.py
@@ -13,7 +13,7 @@ from devices.crypto.cisco import MAGIC as CISCO_MAGIC
 from devices.enums import DeviceStatus
 from devices.models import Router
 from net.enums import ConnectionStatus
-from net.models import Connection
+from net.models import Connection, BFD
 from peering.enums import BGPGroupStatus, BGPSessionStatus, IPFamily
 from peering.models import (
     AutonomousSystem,
@@ -808,6 +808,14 @@ def indent(value, n, chars=" ", reset=False):
 
     return r
 
+def bfds(value):
+    """
+    Returns all the BFDs that have at least one session configured on the router.
+    """
+    if not isinstance(value, Router):
+        raise ValueError("value is not a router")
+    r = BFD.objects.filter(Q(directpeeringsession__router=value) | Q(internetexchangepeeringsession__ixp_connection__router=value))
+    return r
 
 FILTER_DICT = {
     # Generics
@@ -853,6 +861,7 @@ FILTER_DICT = {
     # Routers
     "direct_peers": direct_peers,
     "ixp_peers": ixp_peers,
+    "bfds": bfds,
     # Communities
     "communities": communities,
     "merge_communities": merge_communities,


### PR DESCRIPTION
This PR adds the possiblity to list the associated BFD profiles of a router.
That allows the creation of BFD profiles on supported routers without having to rely on a loop on the sessions, which can cause duplicates of the same BFD profile.

The new Jinja2 filter was named `bfds`.
The PR includes updates to both the documentation and the codebase to support this new functionality.

### New `bfds` filter implementation:

* **Documentation Update**: Added a description and example usage of the `bfds` filter in `docs/templating/jinja2/filters.md`. This explains how to use the filter to fetch BFD profiles for a router.
* **Filter Functionality**: Implemented the `bfds` filter in `peering_manager/jinja2/filters.py`. The filter retrieves all BFD profiles that have at least one session configured on the specified router. It raises a `ValueError` if the input is not a `Router` instance.
* **Filter Registration**: Registered the `bfds` filter in the `FILTER_DICT` dictionary in `peering_manager/jinja2/filters.py`, making it available for use in Jinja2 templates.

### Supporting changes:

* **Model Import Update**: Added the `BFD` model to the imports in `peering_manager/jinja2/filters.py` to support the new filter functionality.


### Example use (VyOS):

```jinja2
{%- set bfd_profiles = router | bfds %}
{%- for bfd in bfd_profiles %}
set protocols bfd profile {{ bfd.slug.upper() }} interval multiplier {{ bfd.detection_multiplier }}
set protocols bfd profile {{ bfd.slug.upper() }} interval receive {{ bfd.minimum_receive_interval }}
set protocols bfd profile {{ bfd.slug.upper() }} interval transmit {{ bfd.minimum_transmit_interval }}
{%- endfor %}
```