### PR TITLE
Closes #928 : Adding routing_policies filter and logic, with document…

### DIFF
--- a/devices/models.py
+++ b/devices/models.py
@@ -5,6 +5,7 @@ import napalm
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models, transaction
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
 
@@ -293,6 +294,71 @@ class Router(PushedDataMixin, PrimaryModel):
             ixp_connection__in=self.get_connections(
                 internet_exchange_point=internet_exchange_point
             )
+        )
+
+    def get_routing_policies(self, detailed=False):
+        """
+        Returns all routing policies that are attached to this router.
+        """
+
+        sessions_policies = RoutingPolicy.objects.filter(
+            Q(directpeeringsession_import_routing_policies__router=self)
+            | Q(directpeeringsession_export_routing_policies__router=self)
+            | Q(
+                internetexchangepeeringsession_import_routing_policies__ixp_connection__router=self
+            )
+            | Q(
+                internetexchangepeeringsession_export_routing_policies__ixp_connection__router=self
+            )
+        ).distinct()
+
+        asn_policies = RoutingPolicy.objects.filter(
+            Q(autonomoussystem_import_routing_policies__router=self)
+            | Q(autonomoussystem_export_routing_policies__router=self)
+        ).distinct()
+
+        bgp_groups_on_router = []
+
+        for group in BGPGroup.objects.all():
+            routers = group.get_routers().filter(id=self.id)
+
+            if routers.exists():
+                bgp_groups_on_router.append(group.id)
+
+        bgp_group_policies = RoutingPolicy.objects.filter(
+            Q(bgpgroup_import_routing_policies__id__in=bgp_groups_on_router)
+            | Q(bgpgroup_export_routing_policies__id__in=bgp_groups_on_router)
+        ).distinct()
+
+        # Get all IXPs that this router is connected to
+
+        ixps_on_router = []
+
+        for ixp in InternetExchange.objects.all():
+            routers = ixp.get_routers().filter(id=self.id)
+
+            if routers.exists():
+                ixps_on_router.append(ixp.id)
+
+        ix_policies = RoutingPolicy.objects.filter(
+            Q(internetexchange_import_routing_policies__id__in=ixps_on_router)
+            | Q(internetexchange_export_routing_policies__id__in=ixps_on_router)
+        ).distinct()
+
+        if detailed:
+            # Get all policies that are used by the router
+
+            return {
+                "sessions_policies": sessions_policies,
+                "asn_policies": asn_policies,
+                "bgp_group_policies": bgp_group_policies,
+                "ix_policies": ix_policies,
+            }
+
+        return (
+            sessions_policies.union(asn_policies)
+            .union(bgp_group_policies)
+            .union(ix_policies)
         )
 
     def get_configuration_context(self):

--- a/docs/templating/jinja2/filters.md
+++ b/docs/templating/jinja2/filters.md
@@ -413,6 +413,30 @@ Examples:
 {% for session in router | direct_peers('transit') %}
 ```
 
+## `routing_policies`
+For a router, fetches all routing policies used on this router. This includes sessions policies, asn policies, bgp group policies and ixp policies.
+
+You can use the argument `detailed` to ask for the policies to be detailed, this will result in a dict with the type of policy as key and the queryset of policies as value.
+
+Key list : `sessions_policies`, `asn_policies`, `bgp_group_policies`, `ix_policies`
+
+Examples:
+```no-highlight
+{%- for policy in router | routing_policies %}
+...
+{%- endfor %}
+
+{%- set policies = router | routing_policies('detailed') %}
+{%- for category, pols in policies.items() %}
+  {%- if category == 'sessions_policies' %}
+    {%- for policy in pols.filter(type='import-policy') %}
+    ...
+    {%- endfor %}
+  {%- endif %}
+{%- endfor %}
+
+```
+
 ## `iter_export_policies` / `iter_import_policies`
 
 Fetches routing policies applied on export or on import of an object. Note

--- a/peering_manager/jinja2/filters.py
+++ b/peering_manager/jinja2/filters.py
@@ -809,6 +809,15 @@ def indent(value, n, chars=" ", reset=False):
     return r
 
 
+def routing_policies(value, detailed=False):
+    """
+    Returns all the routing policies that are applied to the router.
+    """
+    if not isinstance(value, Router):
+        raise ValueError("value is not a router")
+    return value.get_routing_policies(detailed)
+
+
 FILTER_DICT = {
     # Generics
     "safe_string": safe_string,
@@ -853,6 +862,7 @@ FILTER_DICT = {
     # Routers
     "direct_peers": direct_peers,
     "ixp_peers": ixp_peers,
+    "routing_policies": routing_policies,
     # Communities
     "communities": communities,
     "merge_communities": merge_communities,


### PR DESCRIPTION
### Fixes:
#928 

This PR adds the possiblity to list the associated routing policies of a router.

The new Jinja2 filter was named `routing_policies`.
The PR includes updates to both the documentation and the codebase to support this new functionality.
New routing_policies filter implementation:
* Added a new method `get_routing_policies` in `devices/models.py` to retrieve routing policies linked to a router, with an option for detailed output. This includes policies from sessions, ASNs, BGP groups, and IXPs.

* Introduced a new Jinja2 filter `routing_policies` in `peering_manager/jinja2/filters.py` to utilize the `get_routing_policies` method for fetching routing policies within templates.
* Registered the `routing_policies` filter in the `FILTER_DICT` to make it available for use in templates.

### Documentation Updates:
* Added documentation for the `routing_policies` filter in `docs/templating/jinja2/filters.md`, including usage examples and details about the `detailed` argument.


Example use :
```jinja
{%- for policy in router | routing_policies %}
route-policy {{ policy.slug }}
  {{ policy.local_context_data.text_policy }}
end-policy
{%- endfor %}

{%- set policies = router | routing_policies('detailed') %}
{%- for category, pols in policies.items() %}
  {%- if category == 'sessions_policies' %}
    {%- for policy in pols.filter(type='import-policy') %}
    route-policy IN-{{ policy.slug }}
      {{ policy.local_context_data.text_policy }}
    end-policy
    {%- endfor %}
  {%- endif %}
{%- endfor %}
```