### PR TITLE
Closes #938: Always defer AS `prefixes` field

### DIFF
--- a/devices/filtersets.py
+++ b/devices/filtersets.py
@@ -36,17 +36,17 @@ class PlatformFilterSet(OrganisationalModelFilterSet):
 
 class RouterFilterSet(PeeringManagerModelFilterSet):
     local_autonomous_system_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=AutonomousSystem.objects.defer("prefixes"), label="Local AS (ID)"
+        queryset=AutonomousSystem.objects.all(), label="Local AS (ID)"
     )
     local_autonomous_system_asn = django_filters.ModelMultipleChoiceFilter(
         field_name="local_autonomous_system__asn",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="asn",
         label="Local AS (ASN)",
     )
     local_autonomous_system = django_filters.ModelMultipleChoiceFilter(
         field_name="local_autonomous_system__name",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="name",
         label="Local AS (Name)",
     )

--- a/devices/forms.py
+++ b/devices/forms.py
@@ -124,7 +124,7 @@ class RouterForm(PushedDataMixin, PeeringManagerModelForm):
         required=False, queryset=Community.objects.all()
     )
     local_autonomous_system = DynamicModelChoiceField(
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
@@ -223,7 +223,7 @@ class RouterForm(PushedDataMixin, PeeringManagerModelForm):
 class RouterBulkEditForm(PeeringManagerModelBulkEditForm):
     local_autonomous_system = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
@@ -259,7 +259,7 @@ class RouterFilterForm(PeeringManagerModelFilterSetForm):
     model = Router
     local_autonomous_system_id = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )

--- a/devices/models.py
+++ b/devices/models.py
@@ -255,13 +255,13 @@ class Router(PushedDataMixin, PrimaryModel):
             sessions = DirectPeeringSession.objects.filter(router=self).values_list(
                 "autonomous_system", flat=True
             )
-        return AutonomousSystem.objects.defer("prefixes").filter(pk__in=sessions)
+        return AutonomousSystem.objects.filter(pk__in=sessions)
 
     def get_ixp_autonomous_systems(self, internet_exchange_point=None):
         """
         Returns autonomous systems with which this router peers over IXPs.
         """
-        return AutonomousSystem.objects.defer("prefixes").filter(
+        return AutonomousSystem.objects.filter(
             pk__in=InternetExchangePeeringSession.objects.filter(
                 ixp_connection__in=self.get_connections(
                     internet_exchange_point=internet_exchange_point

--- a/peering/api/views.py
+++ b/peering/api/views.py
@@ -51,7 +51,7 @@ class PeeringRootView(APIRootView):
 
 
 class AutonomousSystemViewSet(PeeringManagerModelViewSet):
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     serializer_class = AutonomousSystemSerializer
     filterset_class = AutonomousSystemFilterSet
 

--- a/peering/filtersets.py
+++ b/peering/filtersets.py
@@ -86,32 +86,32 @@ class CommunityFilterSet(PeeringManagerModelFilterSet):
 
 class DirectPeeringSessionFilterSet(PeeringManagerModelFilterSet):
     local_autonomous_system_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=AutonomousSystem.objects.defer("prefixes"), label="Local AS (ID)"
+        queryset=AutonomousSystem.objects.all(), label="Local AS (ID)"
     )
     local_autonomous_system_asn = django_filters.ModelMultipleChoiceFilter(
         field_name="local_autonomous_system__asn",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="asn",
         label="Local AS (ASN)",
     )
     local_autonomous_system = django_filters.ModelMultipleChoiceFilter(
         field_name="local_autonomous_system__name",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="name",
         label="Local AS (Name)",
     )
     autonomous_system_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=AutonomousSystem.objects.defer("prefixes"), label="Remote AS (ID)"
+        queryset=AutonomousSystem.objects.all(), label="Remote AS (ID)"
     )
     autonomous_system_asn = django_filters.ModelMultipleChoiceFilter(
         field_name="autonomous_system__asn",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="asn",
         label="Remote AS (ASN)",
     )
     autonomous_system = django_filters.ModelMultipleChoiceFilter(
         field_name="autonomous_system__name",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="name",
         label="Remote AS (Name)",
     )
@@ -198,17 +198,17 @@ class DirectPeeringSessionFilterSet(PeeringManagerModelFilterSet):
 class InternetExchangeFilterSet(OrganisationalModelFilterSet):
     status = django_filters.MultipleChoiceFilter(choices=BGPGroupStatus, null_value="")
     local_autonomous_system_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=AutonomousSystem.objects.defer("prefixes"), label="Local AS (ID)"
+        queryset=AutonomousSystem.objects.all(), label="Local AS (ID)"
     )
     local_autonomous_system_asn = django_filters.ModelMultipleChoiceFilter(
         field_name="local_autonomous_system__asn",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="asn",
         label="Local AS (ASN)",
     )
     local_autonomous_system = django_filters.ModelMultipleChoiceFilter(
         field_name="local_autonomous_system__name",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="name",
         label="Local AS (Name)",
     )
@@ -232,17 +232,17 @@ class InternetExchangeFilterSet(OrganisationalModelFilterSet):
 
 class InternetExchangePeeringSessionFilterSet(PeeringManagerModelFilterSet):
     autonomous_system_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=AutonomousSystem.objects.defer("prefixes"), label="Remote AS (ID)"
+        queryset=AutonomousSystem.objects.all(), label="Remote AS (ID)"
     )
     autonomous_system_asn = django_filters.ModelMultipleChoiceFilter(
         field_name="autonomous_system__asn",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="asn",
         label="Remote AS (ASN)",
     )
     autonomous_system = django_filters.ModelMultipleChoiceFilter(
         field_name="autonomous_system__name",
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="name",
         label="Remote AS (Name)",
     )

--- a/peering/forms.py
+++ b/peering/forms.py
@@ -307,13 +307,11 @@ class CommunityFilterForm(PeeringManagerModelFilterSetForm):
 
 class DirectPeeringSessionForm(PeeringManagerModelForm):
     local_autonomous_system = DynamicModelChoiceField(
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
-    autonomous_system = DynamicModelChoiceField(
-        queryset=AutonomousSystem.objects.defer("prefixes")
-    )
+    autonomous_system = DynamicModelChoiceField(queryset=AutonomousSystem.objects.all())
     bgp_group = DynamicModelChoiceField(
         required=False, queryset=BGPGroup.objects.all(), label="BGP Group"
     )
@@ -441,7 +439,7 @@ class DirectPeeringSessionForm(PeeringManagerModelForm):
 class DirectPeeringSessionBulkEditForm(PeeringManagerModelBulkEditForm):
     local_autonomous_system = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
@@ -496,14 +494,14 @@ class DirectPeeringSessionFilterForm(PeeringManagerModelFilterSetForm):
     model = DirectPeeringSession
     local_autonomous_system_id = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         to_field_name="pk",
         label="Local AS",
     )
     autonomous_system_id = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="pk",
         label="Autonomous system",
     )
@@ -562,7 +560,7 @@ class InternetExchangeForm(PeeringManagerModelForm):
         required=False, choices=DeviceStatus, widget=StaticSelect
     )
     local_autonomous_system = DynamicModelChoiceField(
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
@@ -621,7 +619,7 @@ class InternetExchangeBulkEditForm(PeeringManagerModelBulkEditForm):
     )
     local_autonomous_system = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
@@ -675,7 +673,7 @@ class InternetExchangeFilterForm(PeeringManagerModelFilterSetForm):
     )
     local_autonomous_system_id = DynamicModelChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )
@@ -741,9 +739,7 @@ class InternetExchangePeeringSessionBulkEditForm(PeeringManagerModelBulkEditForm
 
 
 class InternetExchangePeeringSessionForm(PeeringManagerModelForm):
-    autonomous_system = DynamicModelChoiceField(
-        queryset=AutonomousSystem.objects.defer("prefixes")
-    )
+    autonomous_system = DynamicModelChoiceField(queryset=AutonomousSystem.objects.all())
     internet_exchange = DynamicModelChoiceField(
         required=False, queryset=InternetExchange.objects.all(), label="IXP"
     )
@@ -849,7 +845,7 @@ class InternetExchangePeeringSessionFilterForm(PeeringManagerModelFilterSetForm)
     model = InternetExchangePeeringSession
     autonomous_system_id = DynamicModelMultipleChoiceField(
         required=False,
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         to_field_name="pk",
         label="Autonomous system",
     )

--- a/peering/management/commands/grab_prefixes.py
+++ b/peering/management/commands/grab_prefixes.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         if not quiet:
             self.stdout.write("[*] Fetching prefixes for autonomous systems")
 
-        for autonomous_system in AutonomousSystem.objects.defer("prefixes"):
+        for autonomous_system in AutonomousSystem.objects.all():
             if not quiet:
                 self.stdout.write(f"  - AS{autonomous_system.asn}:")
 

--- a/peering/models/__init__.py
+++ b/peering/models/__init__.py
@@ -35,6 +35,11 @@ __all__ = (
 logger = logging.getLogger("peering.manager.peering")
 
 
+class AutonomousSystemManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().defer("prefixes")
+
+
 class AutonomousSystem(PrimaryModel, PolicyMixin):
     asn = ASNField(unique=True, verbose_name="ASN")
     name = models.CharField(max_length=200)
@@ -61,6 +66,8 @@ class AutonomousSystem(PrimaryModel, PolicyMixin):
     prefixes = models.JSONField(blank=True, null=True, editable=False)
     affiliated = models.BooleanField(default=False)
     contacts = GenericRelation(to="messaging.ContactAssignment")
+
+    objects = AutonomousSystemManager()
 
     class Meta:
         ordering = ["asn", "affiliated"]

--- a/peering/views.py
+++ b/peering/views.py
@@ -384,8 +384,12 @@ class CommunityBulkEdit(BulkEditView):
 
 class DirectPeeringSessionList(ObjectListView):
     permission_required = "peering.view_directpeeringsession"
-    queryset = DirectPeeringSession.objects.order_by(
-        "local_autonomous_system", "autonomous_system", "ip_address"
+    queryset = (
+        DirectPeeringSession.objects.order_by(
+            "local_autonomous_system", "autonomous_system", "ip_address"
+        )
+        .select_related("local_autonomous_system", "autonomous_system")
+        .defer("local_autonomous_system__prefixes", "autonomous_system__prefixes")
     )
     table = DirectPeeringSessionTable
     filterset = DirectPeeringSessionFilterSet
@@ -412,7 +416,9 @@ class DirectPeeringSessionEdit(ObjectEditView):
 
 class DirectPeeringSessionBulkEdit(BulkEditView):
     permission_required = "peering.change_directpeeringsession"
-    queryset = DirectPeeringSession.objects.select_related("autonomous_system")
+    queryset = DirectPeeringSession.objects.select_related("autonomous_system").defer(
+        "autonomous_system__prefixes"
+    )
     filterset = DirectPeeringSessionFilterSet
     table = DirectPeeringSessionTable
     form = DirectPeeringSessionBulkEditForm
@@ -672,8 +678,12 @@ class InternetExchangePeeringDBImport(GetReturnURLMixin, PermissionRequiredMixin
 
 class InternetExchangePeeringSessionList(ObjectListView):
     permission_required = "peering.view_internetexchangepeeringsession"
-    queryset = InternetExchangePeeringSession.objects.order_by(
-        "autonomous_system", "ip_address"
+    queryset = (
+        InternetExchangePeeringSession.objects.order_by(
+            "autonomous_system", "ip_address"
+        )
+        .select_related("autonomous_system")
+        .defer("autonomous_system__prefixes")
     )
     table = InternetExchangePeeringSessionTable
     filterset = InternetExchangePeeringSessionFilterSet
@@ -702,7 +712,7 @@ class InternetExchangePeeringSessionBulkEdit(BulkEditView):
     permission_required = "peering.change_internetexchangepeeringsession"
     queryset = InternetExchangePeeringSession.objects.select_related(
         "autonomous_system"
-    )
+    ).defer("autonomous_system__prefixes")
     filterset = InternetExchangePeeringSessionFilterSet
     table = InternetExchangePeeringSessionTable
     form = InternetExchangePeeringSessionBulkEditForm

--- a/peering/views.py
+++ b/peering/views.py
@@ -87,7 +87,7 @@ from .tables import (
 class AutonomousSystemList(ObjectListView):
     permission_required = "peering.view_autonomoussystem"
     queryset = (
-        AutonomousSystem.objects.defer("prefixes")
+        AutonomousSystem.objects.all()
         .annotate(
             directpeeringsession_count=Count("directpeeringsession", distinct=True),
             internetexchangepeeringsession_count=Count(
@@ -104,7 +104,7 @@ class AutonomousSystemList(ObjectListView):
 
 class AutonomousSystemView(ObjectView):
     permission_required = "peering.view_autonomoussystem"
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     tab = "main"
 
     def get_extra_context(self, request, instance):
@@ -128,30 +128,30 @@ class AutonomousSystemView(ObjectView):
 
 class AutonomousSystemConfigContext(ObjectConfigContextView):
     permission_required = "peering.view_autonomoussystem"
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     base_template = "peering/autonomoussystem/_base.html"
 
 
 class AutonomousSystemEdit(ObjectEditView):
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     form = AutonomousSystemForm
     template_name = "peering/autonomoussystem/edit.html"
 
 
 class AutonomousSystemDelete(ObjectDeleteView):
     permission_required = "peering.delete_autonomoussystem"
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
 
 
 class AutonomousSystemBulkDelete(BulkDeleteView):
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     filterset = AutonomousSystemFilterSet
     table = AutonomousSystemTable
 
 
 class AutonomousSystemPeeringDB(ObjectView):
     permission_required = "peering.view_autonomoussystem"
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     template_name = "peering/autonomoussystem/peeringdb.html"
     tab = "peeringdb"
 
@@ -172,7 +172,7 @@ class AutonomousSystemDirectPeeringSessions(ObjectChildrenView):
         "peering.view_autonomoussystem",
         "peering.view_directpeeringsession",
     )
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     child_model = DirectPeeringSession
     filterset = DirectPeeringSessionFilterSet
     filterset_form = DirectPeeringSessionFilterForm
@@ -193,7 +193,7 @@ class AutonomousSystemInternetExchangesPeeringSessions(ObjectChildrenView):
         "peering.view_autonomoussystem",
         "peering.view_internetexchangepeeringsession",
     )
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     child_model = InternetExchangePeeringSession
     filterset = InternetExchangePeeringSessionFilterSet
     filterset_form = InternetExchangePeeringSessionFilterForm
@@ -211,7 +211,7 @@ class AutonomousSystemInternetExchangesPeeringSessions(ObjectChildrenView):
 
 class AutonomousSystemPeers(ObjectChildrenView):
     permission_required = "peering.view_autonomoussystem"
-    queryset = AutonomousSystem.objects.defer("prefixes")
+    queryset = AutonomousSystem.objects.all()
     child_model = NetworkIXLan
     table = NetworkIXLanTable
     template_name = "peering/autonomoussystem/peers.html"

--- a/peering_manager/constants.py
+++ b/peering_manager/constants.py
@@ -102,7 +102,7 @@ SEARCH_TYPES = OrderedDict(
         (
             "autonomousystem",
             {
-                "queryset": AutonomousSystem.objects.defer("prefixes").annotate(
+                "queryset": AutonomousSystem.objects.all().annotate(
                     directpeeringsession_count=count_related(
                         DirectPeeringSession, "autonomous_system"
                     ),

--- a/peeringdb/forms.py
+++ b/peeringdb/forms.py
@@ -82,7 +82,7 @@ class NetworkIXLanFilterForm(BootstrapMixin, forms.Form):
 
 class SendEmailToNetwork(BootstrapMixin, forms.Form):
     affiliated = DynamicModelChoiceField(
-        queryset=AutonomousSystem.objects.defer("prefixes"),
+        queryset=AutonomousSystem.objects.all(),
         query_params={"affiliated": True},
         label="Local AS",
     )

--- a/peeringdb/jobs.py
+++ b/peeringdb/jobs.py
@@ -45,7 +45,7 @@ def synchronise(job: Job) -> None:
     )
 
     updated_as_count = 0
-    for autonomous_system in AutonomousSystem.objects.defer("prefixes"):
+    for autonomous_system in AutonomousSystem.objects.all():
         if autonomous_system.synchronise_with_peeringdb():
             updated_as_count += 1
 

--- a/peeringdb/management/commands/peeringdb_sync.py
+++ b/peeringdb/management/commands/peeringdb_sync.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
                 self.stdout.write("done", self.style.SUCCESS)
 
             self.stdout.write("[*] Updating AS details")
-            for autonomous_system in AutonomousSystem.objects.defer("prefixes"):
+            for autonomous_system in AutonomousSystem.objects.all():
                 if autonomous_system.is_private:
                     continue
                 if not quiet:


### PR DESCRIPTION
### Fixes:

This change should fix #938 by ensuring that we always defer `prefixes` retrieval for autonomous systems even when AS objects are selected as related objects.