### PR TITLE
Closes #928: Add `routing_policies` Jinja2 filter

### DIFF
--- a/docs/templating/jinja2/filters.md
+++ b/docs/templating/jinja2/filters.md
@@ -475,6 +475,38 @@ export [ {{ session | merge_export_policies | iterate('slug') | join(' ') }} ];
 import [ {{ session | merge_import_policies('reverse') | iterate('slug') | join(' ') }} ];
 ```
 
+## `routing_policies`
+
+For a router, returns a list of all unique routing policies that need to be
+configured on the router.
+
+The returned list contains only unique policies, ordered by their name. This
+is useful for generating the routing policy configuration section of a router.
+
+You can use a string as an option to this filter to select only a specific
+field of the policies. Another optional argument named `family` can be used to
+get policies only matching a given address family. Values for the family
+parameter can be `4` or `6`.
+
+Examples:
+
+```no-highlight
+{% for policy in router | routing_policies %}
+route-policy {{ policy.slug }}
+  # {{ policy.name }}
+  ...
+end-policy
+{% endfor %}
+
+policies [ {{ router | routing_policies('slug') | join(' ') }} ];
+
+{% for policy in router | routing_policies(family=6) %}
+route-policy {{ policy.slug }}
+  ...
+end-policy
+{% endfor %}
+```
+
 ## `communities`
 
 Fetches communities applied to an object.

--- a/peering_manager/jinja2/filters.py
+++ b/peering_manager/jinja2/filters.py
@@ -371,6 +371,30 @@ def iter_import_policies(value, field="", family=-1):
     return list(policies)
 
 
+def routing_policies(value, field="", family=-1):
+    """
+    Returns a list of all unique routing policies needed for a router.
+
+    This filter gathers all routing policies from the resources that the router needs
+    to have configured.
+
+    An optional `field` can be passed as parameter to return only this field's value.
+    An optional `family` can be passed to return only policies matching the address
+    family.
+    """
+    if not isinstance(value, Router):
+        raise ValueError("value is not a router")
+
+    policies = value.get_routing_policies()
+    if family in IPFamily.values():
+        policies = filter(policies, address_family__in=[0, family])
+
+    if field:
+        return [getattr(p, field) for p in policies]
+
+    return list(policies)
+
+
 def communities(value, field=""):
     """
     Returns a list of communities applied to an AS, a group, an IXP or a session.
@@ -884,6 +908,7 @@ FILTER_DICT = {
     "iter_import_policies": iter_import_policies,
     "merge_export_policies": merge_export_policies,
     "merge_import_policies": merge_import_policies,
+    "routing_policies": routing_policies,
     # Config contexts
     "context_has_key": context_has_key,
     "context_has_not_key": context_has_not_key,

--- a/peering_manager/tests/test_jinja2.py
+++ b/peering_manager/tests/test_jinja2.py
@@ -601,3 +601,31 @@ class Jinja2FilterTestCase(TestCase):
         self.assertEqual("  a\n  b\n  c", FILTER_DICT["indent"](data, 2, reset=True))
         data = "a\nb\nc"
         self.assertEqual("\ta\n\tb\n\tc", FILTER_DICT["indent"](data, 1, chars="\t"))
+
+    def test_routing_policies(self):
+        expected = {
+            "accept-all",
+            "export-supernets",
+            "import-known-prefixes",
+            "export-deaggregated-v4",
+            "export-deaggregated-v6",
+            "reject-all",
+        }
+        policies = FILTER_DICT["routing_policies"](self.router)
+        self.assertEqual(expected, {p.slug for p in policies})
+
+        policy_slugs = FILTER_DICT["routing_policies"](self.router, field="slug")
+        self.assertEqual(expected, set(policy_slugs))
+
+        ipv6_policies = FILTER_DICT["routing_policies"](self.router, family=6)
+        ipv6_slugs = {p.slug for p in ipv6_policies}
+        self.assertIn("export-deaggregated-v6", ipv6_slugs)
+        self.assertIn("accept-all", ipv6_slugs)
+        self.assertNotIn("export-deaggregated-v4", ipv6_slugs)
+
+        ipv6_slugs = set(
+            FILTER_DICT["routing_policies"](self.router, field="slug", family=6)
+        )
+        self.assertIn("export-deaggregated-v6", ipv6_slugs)
+        self.assertIn("accept-all", ipv6_slugs)
+        self.assertNotIn("export-deaggregated-v4", ipv6_slugs)


### PR DESCRIPTION
### Fixes: #928

Add a `routing_policies` Jinja2 filter that returns all the policies that should be on a router given what resources are configured on it (BGP groups, IXPs, BGP sessions, remote peers)

Also change the `communities` configuration template variable to use the same value as what the filter returns.