### PR TITLE
Push diff to datasource

### DIFF
--- a/devices/api/serializers.py
+++ b/devices/api/serializers.py
@@ -10,7 +10,12 @@ from ..enums import DeviceStatus
 from ..models import Configuration, Platform, Router
 from .nested_serializers import *
 
-__all__ = ("ConfigurationSerializer", "PlatformSerializer", "RouterSerializer")
+__all__ = (
+    "ConfigurationSerializer",
+    "PlatformSerializer",
+    "RouterPushDiffSerializer",
+    "RouterSerializer",
+)
 
 
 class ConfigurationSerializer(PeeringManagerModelSerializer):
@@ -99,3 +104,20 @@ class RouterSerializer(PeeringManagerModelSerializer):
 class RouterConfigureSerializer(serializers.Serializer):
     routers = serializers.ListField(child=serializers.IntegerField())
     commit = serializers.BooleanField(required=False, default=False)
+
+
+class RouterPushDiffSerializer(serializers.Serializer):
+    router = serializers.IntegerField()
+    diff_content = serializers.CharField(allow_blank=False)
+
+    def validate_router(self, value):
+        try:
+            router = Router.objects.get(pk=value)
+        except Router.DoesNotExist as exc:
+            raise serializers.ValidationError("Router not found.") from exc
+
+        if not router.data_source or not router.data_path:
+            raise serializers.ValidationError(
+                "Router does not have a data source and data path configured."
+            )
+        return value

--- a/devices/api/views.py
+++ b/devices/api/views.py
@@ -16,6 +16,7 @@ from ..filtersets import ConfigurationFilterSet, PlatformFilterSet, RouterFilter
 from ..jobs import (
     poll_bgp_sessions,
     push_configuration_to_data_source,
+    push_diff_to_data_source,
     render_configuration,
     set_napalm_configuration,
     test_napalm_connection,
@@ -25,6 +26,7 @@ from .serializers import (
     ConfigurationSerializer,
     PlatformSerializer,
     RouterConfigureSerializer,
+    RouterPushDiffSerializer,
     RouterSerializer,
 )
 
@@ -375,5 +377,50 @@ class RouterViewSet(PeeringManagerModelViewSet):
 
         return Response(
             JobSerializer(jobs, many=True, context={"request": request}).data,
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    @extend_schema(
+        operation_id="devices_routers_push_diff_datasource",
+        request=RouterPushDiffSerializer,
+        responses={
+            202: OpenApiResponse(
+                response=JobSerializer,
+                description="Job scheduled to push configuration diff to data source.",
+            ),
+            400: OpenApiResponse(
+                response=OpenApiTypes.NONE,
+                description="Invalid request (missing fields, empty diff, or router without data source).",
+            ),
+            403: OpenApiResponse(
+                response=OpenApiTypes.NONE,
+                description="The user does not have the permission to push to data sources.",
+            ),
+        },
+    )
+    @action(detail=False, methods=["post"], url_path="push-diff-datasource")
+    def push_diff_datasource(self, request):
+        if not request.user.has_perm(
+            "devices.push_router_configuration_to_data_source"
+        ):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        serializer = RouterPushDiffSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        router = Router.objects.get(pk=serializer.validated_data["router"])
+        diff_content = serializer.validated_data["diff_content"]
+
+        job = Job.enqueue(
+            push_diff_to_data_source,
+            router,
+            diff_content,
+            name="devices.router.push_diff_to_data_source",
+            object=router,
+            user=request.user,
+        )
+
+        return Response(
+            JobSerializer(instance=job, context={"request": request}).data,
             status=status.HTTP_202_ACCEPTED,
         )

--- a/devices/jobs.py
+++ b/devices/jobs.py
@@ -134,3 +134,36 @@ def push_configuration_to_data_source(router, job):
         raise e
 
     return True
+
+
+@job("default")
+def push_diff_to_data_source(router, diff_content, job):
+    if not router.data_source or not router.data_path:
+        job.mark_completed("No data source and file to push diff to")
+        return False
+
+    diff_path = f"{router.data_path}.diff"
+    job.mark_running(
+        f"Pushing configuration diff to {router.data_source}:{diff_path}.",
+        object=router,
+        logger=logger,
+    )
+
+    try:
+        router.data_source.push(diff_path, diff_content)
+        job.mark_completed("Diff pushed to data source.", object=router, logger=logger)
+    except Exception as e:
+        job.set_output(str(e))
+        job.mark_failed(
+            "Failed to push diff to data source.", object=router, logger=logger
+        )
+        router.data_source.status = DataSourceStatus.FAILED
+        router.data_source.save()
+
+        if isinstance(e, SynchronisationError):
+            logger.error(e)
+            return False
+
+        raise e
+
+    return True

--- a/templates/devices/router/configuration.html
+++ b/templates/devices/router/configuration.html
@@ -38,7 +38,18 @@
       <div class="modal-body" id="main-body">
       </div>
       <div class="modal-footer" id="main-footer">
-        <button type="button" class="btn btn-primary invisible" id="commit">Commit changes</button>
+        <div class="btn-group invisible" id="commit-group">
+          <button type="button" class="btn btn-primary" id="commit">Commit changes</button>
+          <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" id="commit-dropdown" data-bs-toggle="dropdown" aria-expanded="false">
+            <span class="visually-hidden">More actions</span>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            {% if perms.devices.push_router_configuration_to_data_source and instance.data_source and instance.data_path %}
+            <li><a class="dropdown-item" href="#" id="push-diff-datasource"><i class="fa fa-upload"></i> Push Diff to Data Source</a></li>
+            {% endif %}
+            <li><a class="dropdown-item" href="#" id="download-diff"><i class="fa fa-download"></i> Download Diff</a></li>
+          </ul>
+        </div>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
       </div>
     </div>
@@ -98,6 +109,7 @@
   {% if perms.devices.deploy_router_configuration and instance.is_usable_for_task %}
   function deployFailHandler() {
     PeeringManager.setFailedButton($('#commit'), 'An error occurred');
+    syncCommitToggle();
   }
   function deployDoneHandler(r) {
     switch (r['status']['value']) {
@@ -109,12 +121,14 @@
         break;
       case 'completed':
         PeeringManager.setSuccessButton($('#commit'), 'Configuration saved');
+        syncCommitToggle();
         break;
       case 'errored':
       case 'failed':
       default:
         $('#main-body').html('<p>An error occured while trying to commit the configuration changes.</p><p>You can find more details in the napalm logs or below.</p><pre class="pre-scrollable">' + r['output'] + '</pre>');
         PeeringManager.setFailedButton($('#commit'), 'Configuration not saved');
+        syncCommitToggle();
         break;
     }
   }
@@ -136,7 +150,8 @@
           if (maintenance) {
             modal_text = '<div class="alert alert-warning" role="alert">This router is in maintenance, proceed with care!</div>' + modal_text;
           }
-          $('#commit').removeClass('invisible');
+          currentDiffOutput = output;
+          $('#commit-group').removeClass('invisible');
         }
         $('#main-body').html(modal_text);
         break;
@@ -148,15 +163,34 @@
     }
   }
 
-  // When the modal is closed, reset the button back to its defaults
+  // Sync the dropdown toggle colour with the commit button
+  function syncCommitToggle() {
+    var toggle = $('#commit-dropdown');
+    toggle.removeClass('btn-primary btn-warning btn-danger btn-success');
+    var commit = $('#commit');
+    if (commit.hasClass('btn-warning')) toggle.addClass('btn-warning');
+    else if (commit.hasClass('btn-danger')) toggle.addClass('btn-danger');
+    else if (commit.hasClass('btn-success')) toggle.addClass('btn-success');
+    else toggle.addClass('btn-primary');
+  }
+
+  // When the modal is closed, reset the buttons back to their defaults
   $('#main-modal').on('hidden.bs.modal', function (e) {
     var button = $('#commit');
     button.removeAttr('disabled');
-    button.removeClass(['btn-warning', 'btn-danger', 'btn-success']).addClass(['btn-primary', 'invisible']);
+    button.removeClass(['btn-warning', 'btn-danger', 'btn-success']).addClass('btn-primary');
     button.html('Commit changes');
-    console.log(button);
+
+    $('#commit-group').addClass('invisible');
+    $('#commit-dropdown').removeClass('btn-warning btn-danger btn-success').addClass('btn-primary');
+
+    $('#push-diff-datasource').removeClass('disabled').html('<i class="fa fa-upload"></i> Push Diff to Data Source');
+    $('#download-diff').html('<i class="fa fa-download"></i> Download Diff');
+
+    currentDiffOutput = '';
   });
 
+  var currentDiffOutput = '';
   var maintenance = {% if instance.status == 'maintenance' %}true{% else %}false{% endif %};
   $('#deploy').click(function () {
     // Enable compare before commit if switch is checked or if the router is in maintenance mode
@@ -187,8 +221,61 @@
       data: { 'routers': [{{ instance.pk }}], 'commit': true },
     }).done(function (r) {
       PeeringManager.setWorkingButton($('#commit'));
+      syncCommitToggle();
       deployDoneHandler(r[0]);
     });
+  });
+
+  // Push diff to data source
+  function pushDiffDoneHandler(r) {
+    var item = $('#push-diff-datasource');
+    switch (r['status']['value']) {
+      case 'pending':
+      case 'running':
+        setTimeout(function () {
+          PeeringManager.pollJob(r, pushDiffDoneHandler);
+        }, 2000);
+        break;
+      case 'completed':
+        item.addClass('disabled').html('<i class="fa-fw fa-solid fa-check text-success"></i> Diff pushed to data source');
+        break;
+      case 'errored':
+      case 'failed':
+      default:
+        item.addClass('disabled').html('<i class="fa-fw fa-solid fa-times text-danger"></i> Failed to push diff');
+        break;
+    }
+  }
+  $('#push-diff-datasource').click(function (e) {
+    e.preventDefault();
+    if ($(this).hasClass('disabled')) return;
+    var item = $(this);
+    item.addClass('disabled').html('<i class="fa-fw fa-solid fa-sync fa-spin"></i> Pushing...');
+    $.ajax({
+      method: 'post',
+      url: "{% url 'devices-api:router-push-diff-datasource' %}",
+      headers: { 'X-CSRFTOKEN': '{{ csrf_token }}' },
+      contentType: 'application/json',
+      data: JSON.stringify({ 'router': {{ instance.pk }}, 'diff_content': currentDiffOutput }),
+    }).done(function (r) {
+      pushDiffDoneHandler(r);
+    }).fail(function () {
+      item.html('<i class="fa-fw fa-solid fa-times text-danger"></i> Failed to push diff');
+    });
+  });
+
+  // Download diff as local file
+  $('#download-diff').click(function (e) {
+    e.preventDefault();
+    var blob = new Blob([currentDiffOutput], { type: 'text/plain' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = '{{ instance.name }}.diff';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   });
   {% endif %}
   {% if perms.devices.push_router_configuration_to_data_source %}

--- a/templates/devices/router/configuration.html
+++ b/templates/devices/router/configuration.html
@@ -59,130 +59,75 @@
 {% endblock %}
 {% block javascript %}
 <script>
+  var POLL_INTERVAL_MS = 2000;
+
+  // Generic job result handler — eliminates the duplicated switch/case polling pattern
+  function handleJobResult(r, callbacks) {
+    switch (r['status']['value']) {
+      case 'pending':
+      case 'running':
+        setTimeout(function () {
+          PeeringManager.pollJob(r, function (r) { handleJobResult(r, callbacks); }, callbacks.onPollError);
+        }, POLL_INTERVAL_MS);
+        break;
+      case 'completed':
+        if (callbacks.onCompleted) callbacks.onCompleted(r);
+        break;
+      case 'errored':
+      case 'failed':
+      default:
+        if (callbacks.onFailed) callbacks.onFailed(r);
+        break;
+    }
+  }
+
   $(document).ready(function () {
     $.ajax({
       method: 'get',
       url: "{% url 'devices-api:router-configuration' pk=instance.pk %}"
     }).done(function (r) {
       $('#configuration').html('<div class="text-center" style="font-size: 2rem;"><i class="fa-fw fa-solid fa-rotate fa-spin"></i> Working</div>');
-      configDoneHandler(r);
+      handleJobResult(r, {
+        onCompleted: function (r) {
+          var config = r['output'];
+          if (config == "") {
+            $('#configuration').html('<p>Configuration is empty.</p>');
+          } else {
+            $('#configuration').html('<pre class="pre-scrollable"><code>' + PeeringManager.escapeHTML(config) + '</code></pre>');
+          }
+        },
+        onFailed: function () {
+          $('#configuration').html('<p>An error occured while generating the configuration.</p>');
+        }
+      });
     }).fail(function () {
       $('#configuration').html('<p>Unable to render router configuration.</p>');
     });
   });
 
-  // Bind copy to clipboard function to the button
+  // Copy to clipboard
   $('#copy-config').click(function () {
-    var temp = $('<textarea>');
-    $('body').append(temp);
-    temp.val($('.pre-scrollable').text()).select();
-    document.execCommand('copy');
-    temp.remove();
+    navigator.clipboard.writeText($('.pre-scrollable').text());
   });
 
-  function configDoneHandler(r) {
-    switch (r['status']['value']) {
-      case 'pending':
-      case 'running':
-        setTimeout(function() {
-          PeeringManager.pollJob(r, configDoneHandler);
-        }, 2000);
-        break;
-      case 'completed':
-        var formatted;
-        var config = r['output'];
-        if (config == "") {
-          formatted = '<p>Configuration is empty.</p>';
-        } else {
-          formatted = '<pre class="pre-scrollable"><code>' + PeeringManager.escapeHTML(config) + '</code></pre>';
-        }
-        $('#configuration').html(formatted);
-        break;
-      case 'errored':
-      case 'failed':
-      default:
-        $('#configuration').html('<p>An error occured while generating the configuration.</p>');
-        break;
-    }
-  }
-
   {% if perms.devices.deploy_router_configuration and instance.is_usable_for_task %}
-  function deployFailHandler() {
-    PeeringManager.setFailedButton($('#commit'), 'An error occurred');
-    syncCommitToggle();
-  }
-  function deployDoneHandler(r) {
-    switch (r['status']['value']) {
-      case 'pending':
-      case 'running':
-        setTimeout(function () {
-          PeeringManager.pollJob(r, deployDoneHandler, deployFailHandler);
-        }, 2000);
-        break;
-      case 'completed':
-        PeeringManager.setSuccessButton($('#commit'), 'Configuration saved');
-        syncCommitToggle();
-        break;
-      case 'errored':
-      case 'failed':
-      default:
-        $('#main-body').html('<p>An error occured while trying to commit the configuration changes.</p><p>You can find more details in the napalm logs or below.</p><pre class="pre-scrollable">' + r['output'] + '</pre>');
-        PeeringManager.setFailedButton($('#commit'), 'Configuration not saved');
-        syncCommitToggle();
-        break;
-    }
-  }
-  function checkDoneHandler(r) {
-    switch (r['status']['value']) {
-      case 'pending':
-      case 'running':
-        setTimeout(function() {
-          PeeringManager.pollJob(r, checkDoneHandler);
-        }, 2000);
-        break;
-      case 'completed':
-        var modal_text;
-        var output = r['output'];
-        if (output == "") {
-          modal_text = '<p>No configuration differences found.</p>';
-        } else {
-          modal_text = '<p>Configuration differences:</p><pre class="pre-scrollable">' + PeeringManager.escapeHTML(output) + '</pre>';
-          if (maintenance) {
-            modal_text = '<div class="alert alert-warning" role="alert">This router is in maintenance, proceed with care!</div>' + modal_text;
-          }
-          currentDiffOutput = output;
-          $('#commit-group').removeClass('invisible');
-        }
-        $('#main-body').html(modal_text);
-        break;
-      case 'errored':
-      case 'failed':
-      default:
-        $('#main-body').html('<p>An error occured while trying to check for changes.</p><p>The router may be unreachable, the configuration may be locked by another user or the configuration may be invalid.</p><p>You can find more details in the <code>logs/napalm.log</code> logs file or below.</p><pre class="pre-scrollable">' + r['output'] + '</pre>');
-        break;
-    }
+  var currentDiffOutput = '';
+  var maintenance = {% if instance.status == 'maintenance' %}true{% else %}false{% endif %};
+
+  // Set the dropdown toggle variant to match the commit button
+  function setCommitToggleVariant(variant) {
+    $('#commit-dropdown').removeClass('btn-primary btn-warning btn-danger btn-success').addClass(variant);
   }
 
-  // Sync the dropdown toggle colour with the commit button
-  function syncCommitToggle() {
-    var toggle = $('#commit-dropdown');
-    toggle.removeClass('btn-primary btn-warning btn-danger btn-success');
-    var commit = $('#commit');
-    if (commit.hasClass('btn-warning')) toggle.addClass('btn-warning');
-    else if (commit.hasClass('btn-danger')) toggle.addClass('btn-danger');
-    else if (commit.hasClass('btn-success')) toggle.addClass('btn-success');
-    else toggle.addClass('btn-primary');
-  }
-
-  // When the modal is closed, reset the buttons back to their defaults
-  $('#main-modal').on('hidden.bs.modal', function (e) {
+  // When the modal is closed, reset all buttons to defaults
+  $('#main-modal').on('hidden.bs.modal', function () {
     var button = $('#commit');
     button.removeAttr('disabled');
     button.removeClass(['btn-warning', 'btn-danger', 'btn-success']).addClass('btn-primary');
     button.html('Commit changes');
 
     $('#commit-group').addClass('invisible');
-    $('#commit-dropdown').removeClass('btn-warning btn-danger btn-success').addClass('btn-primary');
+    setCommitToggleVariant('btn-primary');
 
     $('#push-diff-datasource').removeClass('disabled').html('<i class="fa fa-upload"></i> Push Diff to Data Source');
     $('#download-diff').html('<i class="fa fa-download"></i> Download Diff');
@@ -190,14 +135,8 @@
     currentDiffOutput = '';
   });
 
-  var currentDiffOutput = '';
-  var maintenance = {% if instance.status == 'maintenance' %}true{% else %}false{% endif %};
   $('#deploy').click(function () {
-    // Enable compare before commit if switch is checked or if the router is in maintenance mode
-    var commit = true;
-    if ($('#compare-switch').is(':checked') || maintenance) {
-      commit = false;
-    }
+    var commit = !($('#compare-switch').is(':checked') || maintenance);
 
     $.ajax({
       method: 'post',
@@ -207,12 +146,32 @@
     }).done(function (r) {
       $('#main-body').html('<div class="text-center" style="font-size: 2rem;"><i class="fa-fw fa-solid fa-rotate fa-spin"></i> Working</div>');
       $('#main-modal').modal('show');
-      checkDoneHandler(r[0]);
+      handleJobResult(r[0], {
+        onCompleted: function (r) {
+          var output = r['output'];
+          var modal_text;
+          if (output == "") {
+            modal_text = '<p>No configuration differences found.</p>';
+          } else {
+            modal_text = '<p>Configuration differences:</p><pre class="pre-scrollable">' + PeeringManager.escapeHTML(output) + '</pre>';
+            if (maintenance) {
+              modal_text = '<div class="alert alert-warning" role="alert">This router is in maintenance, proceed with care!</div>' + modal_text;
+            }
+            currentDiffOutput = output;
+            $('#commit-group').removeClass('invisible');
+          }
+          $('#main-body').html(modal_text);
+        },
+        onFailed: function (r) {
+          $('#main-body').html('<p>An error occured while trying to check for changes.</p><p>The router may be unreachable, the configuration may be locked by another user or the configuration may be invalid.</p><p>You can find more details in the <code>logs/napalm.log</code> logs file or below.</p><pre class="pre-scrollable">' + r['output'] + '</pre>');
+        }
+      });
     }).fail(function (r) {
       $('#main-body').html('<p>Unable to schedule configuration deployment.</p><pre class="pre-scrollable">' + r + '</pre>');
       $('#main-modal').modal('show');
     });
   });
+
   $('#commit').click(function () {
     $.ajax({
       method: 'post',
@@ -221,31 +180,29 @@
       data: { 'routers': [{{ instance.pk }}], 'commit': true },
     }).done(function (r) {
       PeeringManager.setWorkingButton($('#commit'));
-      syncCommitToggle();
-      deployDoneHandler(r[0]);
+      setCommitToggleVariant('btn-warning');
+      handleJobResult(r[0], {
+        onCompleted: function () {
+          PeeringManager.setSuccessButton($('#commit'), 'Configuration saved');
+          setCommitToggleVariant('btn-success');
+        },
+        onFailed: function (r) {
+          $('#main-body').html('<p>An error occured while trying to commit the configuration changes.</p><p>You can find more details in the napalm logs or below.</p><pre class="pre-scrollable">' + r['output'] + '</pre>');
+          PeeringManager.setFailedButton($('#commit'), 'Configuration not saved');
+          setCommitToggleVariant('btn-danger');
+        },
+        onPollError: function () {
+          PeeringManager.setFailedButton($('#commit'), 'An error occurred');
+          setCommitToggleVariant('btn-danger');
+        }
+      });
+    }).fail(function () {
+      PeeringManager.setFailedButton($('#commit'), 'An error occurred');
+      setCommitToggleVariant('btn-danger');
     });
   });
 
   // Push diff to data source
-  function pushDiffDoneHandler(r) {
-    var item = $('#push-diff-datasource');
-    switch (r['status']['value']) {
-      case 'pending':
-      case 'running':
-        setTimeout(function () {
-          PeeringManager.pollJob(r, pushDiffDoneHandler);
-        }, 2000);
-        break;
-      case 'completed':
-        item.addClass('disabled').html('<i class="fa-fw fa-solid fa-check text-success"></i> Diff pushed to data source');
-        break;
-      case 'errored':
-      case 'failed':
-      default:
-        item.addClass('disabled').html('<i class="fa-fw fa-solid fa-times text-danger"></i> Failed to push diff');
-        break;
-    }
-  }
   $('#push-diff-datasource').click(function (e) {
     e.preventDefault();
     if ($(this).hasClass('disabled')) return;
@@ -258,7 +215,14 @@
       contentType: 'application/json',
       data: JSON.stringify({ 'router': {{ instance.pk }}, 'diff_content': currentDiffOutput }),
     }).done(function (r) {
-      pushDiffDoneHandler(r);
+      handleJobResult(r, {
+        onCompleted: function () {
+          item.html('<i class="fa-fw fa-solid fa-check text-success"></i> Diff pushed to data source');
+        },
+        onFailed: function () {
+          item.html('<i class="fa-fw fa-solid fa-times text-danger"></i> Failed to push diff');
+        }
+      });
     }).fail(function () {
       item.html('<i class="fa-fw fa-solid fa-times text-danger"></i> Failed to push diff');
     });
@@ -278,25 +242,8 @@
     URL.revokeObjectURL(url);
   });
   {% endif %}
+
   {% if perms.devices.push_router_configuration_to_data_source %}
-  function configPushDataSourceHandler(r) {
-    switch (r['status']['value']) {
-      case 'pending':
-      case 'running':
-        setTimeout(function() {
-          PeeringManager.pollJob(r, configPushDataSourceHandler);
-        }, 2000);
-        break;
-      case 'completed':
-        PeeringManager.setSuccessOutlineButton($('#push-datasource'), 'Pushed to data source');
-        break;
-      case 'errored':
-      case 'failed':
-      default:
-        PeeringManager.setFailedOutlineButton($('#push-datasource'), 'Failed data source push');
-        break;
-    }
-  }
   $('#push-datasource').click(function () {
     $.ajax({
       method: 'post',
@@ -305,7 +252,14 @@
       data: { 'routers': [{{ instance.pk }}] },
     }).done(function (r) {
       PeeringManager.setWorkingOutlineButton($('#push-datasource'));
-      configPushDataSourceHandler(r[0]);
+      handleJobResult(r[0], {
+        onCompleted: function () {
+          PeeringManager.setSuccessOutlineButton($('#push-datasource'), 'Pushed to data source');
+        },
+        onFailed: function () {
+          PeeringManager.setFailedOutlineButton($('#push-datasource'), 'Failed data source push');
+        }
+      });
     });
   });
   {% endif %}


### PR DESCRIPTION
### Fixes: #882

Add support for pushing a diff to a data source. When a router has a data source and a data file, we now support to push a diff instead of a complete configuration to the data source. The file will be named like `<data file name>.diff`. This can be done after clicking the "Deploy" button. If a diff is shown, 2 new buttons to push the diff to the data source or download the diff will be in a dropdown attached to the "Commit" button.

This change also improves the JS code in general by removing some code duplication and also getting rid of the old way of copying a value to the clipboard (now it uses  a modern API).