### PR TITLE
Closes #972: Do not store an empty prefix set when an IRR lookup fails

### DIFF
--- a/peering/management/commands/get_irr_data.py
+++ b/peering/management/commands/get_irr_data.py
@@ -88,6 +88,8 @@ class Command(BaseCommand):
                 )
                 autonomous_system.as_list = self.retrieve_as_list(autonomous_system=autonomous_system, quiet=quiet)
             except UnresolvableIRRObjectError:
+                if not quiet:
+                    self.stdout.write("    skipped (IRR lookup failed, keeping stored data)", self.style.WARNING)
                 continue
 
             autonomous_system.save(update_fields=["prefixes", "as_list"])

--- a/peering/management/commands/grab_prefixes.py
+++ b/peering/management/commands/grab_prefixes.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
+from peering.functions import UnresolvableIRRObjectError
 from peering.models import AutonomousSystem
 
 
@@ -37,6 +38,11 @@ class Command(BaseCommand):
 
             try:
                 prefixes = autonomous_system.retrieve_irr_as_set_prefixes()
+            except UnresolvableIRRObjectError:
+                # Skip this AS, keeping its stored prefixes, instead of failing the run
+                if not quiet:
+                    self.stdout.write("    skipped (IRR lookup failed)", self.style.WARNING)
+                continue
             except ValueError as exc:
                 raise CommandError(str(exc)) from exc
 

--- a/peering/models/__init__.py
+++ b/peering/models/__init__.py
@@ -418,35 +418,37 @@ class AutonomousSystem(PrimaryModel, PolicyMixin, JournalingMixin):
         This function will actually retrieve prefixes from IRR online sources. It is
         expected to be slow due to network operations and depending on the size of the
         data to process.
+
+        Raises:
+            UnresolvableIRRObjectError: if an IRR object cannot be resolved. Callers
+            must not store the returned value in that case: an empty prefix set caused
+            by a failed lookup cannot be told apart from an AS announcing nothing.
         """
         prefixes = {"ipv6": [], "ipv4": []}
 
         if not self.retrieve_prefixes:
             return prefixes
 
-        try:
-            # For each AS-SET try getting IPv6 and IPv4 prefixes
-            for source, as_set in parse_irr_as_set(asn=self.asn, irr_as_set=self.irr_as_set):
-                prefixes["ipv6"].extend(
-                    call_irr_as_set_resolver(
-                        as_set=as_set,
-                        source=source,
-                        address_family=6,
-                        irr_sources_override=self.irr_sources_override,
-                        irr_ipv6_prefixes_args_override=self.irr_ipv6_prefixes_args_override,
-                    )
+        # For each AS-SET try getting IPv6 and IPv4 prefixes
+        for source, as_set in parse_irr_as_set(asn=self.asn, irr_as_set=self.irr_as_set):
+            prefixes["ipv6"].extend(
+                call_irr_as_set_resolver(
+                    as_set=as_set,
+                    source=source,
+                    address_family=6,
+                    irr_sources_override=self.irr_sources_override,
+                    irr_ipv6_prefixes_args_override=self.irr_ipv6_prefixes_args_override,
                 )
-                prefixes["ipv4"].extend(
-                    call_irr_as_set_resolver(
-                        as_set=as_set,
-                        source=source,
-                        address_family=4,
-                        irr_sources_override=self.irr_sources_override,
-                        irr_ipv4_prefixes_args_override=self.irr_ipv4_prefixes_args_override,
-                    )
+            )
+            prefixes["ipv4"].extend(
+                call_irr_as_set_resolver(
+                    as_set=as_set,
+                    source=source,
+                    address_family=4,
+                    irr_sources_override=self.irr_sources_override,
+                    irr_ipv4_prefixes_args_override=self.irr_ipv4_prefixes_args_override,
                 )
-        except UnresolvableIRRObjectError:
-            pass
+            )
 
         return prefixes
 
@@ -459,11 +461,26 @@ class AutonomousSystem(PrimaryModel, PolicyMixin, JournalingMixin):
         returned. 6 for IPv6, 4 for IPv4, both for all other values.
 
         The stored database value will be used if it exists.
+
+        Unlike `retrieve_irr_as_set_prefixes`, this does not raise if the IRR lookup
+        fails: it is used while rendering configurations. It returns an empty prefix
+        set instead, without caching it. This covers unresolvable IRR objects as well
+        as unparsable resolver output, which surfaces as a `ValueError`.
         """
-        prefixes = self.prefixes or self.retrieve_irr_as_set_prefixes()
-        if prefixes != self.prefixes:
-            self.prefixes = prefixes
-            self.save(update_fields=["prefixes"])
+        prefixes = self.prefixes
+        if not prefixes:
+            try:
+                prefixes = self.retrieve_irr_as_set_prefixes()
+            except UnresolvableIRRObjectError as exc:
+                logger.warning(f"cannot resolve {exc.object} for as{self.asn}, not caching an empty prefix set")
+                prefixes = {"ipv6": [], "ipv4": []}
+            except ValueError as exc:
+                logger.warning(f"cannot parse irr prefixes for as{self.asn}, not caching an empty prefix set: {exc}")
+                prefixes = {"ipv6": [], "ipv4": []}
+            else:
+                if prefixes != self.prefixes:
+                    self.prefixes = prefixes
+                    self.save(update_fields=["prefixes"])
 
         if address_family == 6:
             return prefixes["ipv6"]

--- a/peering/tests/test_models.py
+++ b/peering/tests/test_models.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.test import TestCase
 
 from bgp.models import Relationship
@@ -80,8 +81,22 @@ class AutonomousSystemTest(TestCase):
 
         with patch("peering.functions.subprocess.Popen", side_effect=mocked_subprocess_popen):
             self.autonomous_system.irr_as_set = "AS-ERROR"
-            prefixes = self.autonomous_system.retrieve_irr_as_set_prefixes()
-            self.assertEqual({"ipv6": [], "ipv4": []}, prefixes)
+            with self.assertRaises(UnresolvableIRRObjectError):
+                self.autonomous_system.retrieve_irr_as_set_prefixes()
+
+    def test_get_irr_data_keeps_stored_prefixes_on_failure(self):
+        stored = {"ipv6": [{"prefix": "2001:db8::/32"}], "ipv4": [{"prefix": "192.0.2.0/24"}]}
+        # get_irr_data reads the autonomous systems back from the database, so the
+        # failing AS-SET has to be persisted alongside the prefixes we expect to keep.
+        self.autonomous_system.irr_as_set = "AS-ERROR"
+        self.autonomous_system.prefixes = stored
+        self.autonomous_system.save(update_fields=["irr_as_set", "prefixes"])
+
+        with patch("peering.functions.subprocess.Popen", side_effect=mocked_subprocess_popen):
+            call_command("get_irr_data", verbosity=0)
+
+        self.autonomous_system.refresh_from_db()
+        self.assertEqual(stored, self.autonomous_system.prefixes)
 
     def test_get_irr_as_set_prefixes(self):
         with patch("peering.functions.subprocess.Popen", side_effect=mocked_subprocess_popen):
@@ -92,6 +107,18 @@ class AutonomousSystemTest(TestCase):
         prefixes = self.autonomous_system.get_irr_as_set_prefixes()
         self.assertEqual(self.autonomous_system.prefixes["ipv6"], prefixes["ipv6"])
         self.assertEqual(self.autonomous_system.prefixes["ipv4"], prefixes["ipv4"])
+
+    def test_get_irr_as_set_prefixes_does_not_cache_failure(self):
+        self.autonomous_system.prefixes = None
+        self.autonomous_system.save(update_fields=["prefixes"])
+
+        with patch("peering.functions.subprocess.Popen", side_effect=mocked_subprocess_popen):
+            self.autonomous_system.irr_as_set = "AS-ERROR"
+            prefixes = self.autonomous_system.get_irr_as_set_prefixes()
+
+        self.assertEqual({"ipv6": [], "ipv4": []}, prefixes)
+        self.autonomous_system.refresh_from_db()
+        self.assertIsNone(self.autonomous_system.prefixes)
 
     def test_peeringdb_network(self):
         self.assertIsNone(self.autonomous_system.peeringdb_network)


### PR DESCRIPTION

When an IRR lookup fails, retrieve_irr_as_set_prefixes was silently returning an empty prefix set instead of raising. get_irr_data then saved that empty set, wiping out the previously stored prefixes for that AS.

please feel free to comment on this or request  changes. 

### Fixes: #972 

let the failure raise, so get_irr_data skips the AS and keeps the old data instead of overwriting it with nothing. get_irr_as_set_prefixes (used for rendering configs) still returns an empty set on failure like before, but no longer caches it.

Also fixed the deprecated grab_prefixes command which would have started crashing with the same change, and added tests for the failure case.
